### PR TITLE
refactor: introduce strongly-typed BuildArgs enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,5 @@
+pub mod commands;
+pub mod fat;
+pub mod fwup;
+pub mod log;
+pub mod manifest;

--- a/tests/commands/stone/build/mod.rs
+++ b/tests/commands/stone/build/mod.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use stone::fat::list_fat_files;
 use tempfile::TempDir;
 
 #[test]
@@ -20,8 +21,25 @@ fn test_build() {
         .assert()
         .success();
 
+    // Check that the images were created
     assert!(output_path.join("image_1").exists());
     assert!(output_path.join("image_2").exists());
+
+    // Check that the FAT image contains the expected files
+    let fat_image_path = output_path.join("image_1");
+    let fat_files = list_fat_files(&fat_image_path).expect("Failed to list FAT files");
+
+    // The manifest specifies these files should be in the FAT image:
+    // - "file_1" (direct mapping)
+    // - "file_2" -> "foo/file_2" (mapped to subdirectory)
+    assert!(
+        fat_files.contains(&"file_1".to_string()),
+        "FAT image should contain file_1, found files: {fat_files:?}"
+    );
+    assert!(
+        fat_files.contains(&"foo/file_2".to_string()),
+        "FAT image should contain foo/file_2, found files: {fat_files:?}"
+    );
 }
 
 #[test]

--- a/tests/fixtures/coverage/stone.json
+++ b/tests/fixtures/coverage/stone.json
@@ -41,6 +41,8 @@
         },
         {
           "image": "image_2",
+          "size": 1024,
+          "size_unit": "mebibytes",
           "expand": "true"
         }
       ]


### PR DESCRIPTION
Replace loose HashMap-based build_args with typed BuildArgs enum variants for FAT and fwup builds.

- Add BuildArgs enum with Fat and Fwup variants
- Move files array from Image to BuildArgs::Fat
- Make size/size_unit required fields for Object images