### PR TITLE
Updates for create / build on imx targets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -532,7 +532,7 @@ checksum = "9d26fcce2f397e5488affdf681b20c030aa9faa877b92b1825e5d66b08d2fc33"
 
 [[package]]
 name = "stone"
-version = "1.4.0"
+version = "1.4.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stone"
-version = "1.4.0"
+version = "1.4.1"
 edition = "2024"
 description = "A CLI for managing Avocado stones."
 homepage = "https://github.com/avocado-linux/stone"

--- a/src/commands/stone/provision.rs
+++ b/src/commands/stone/provision.rs
@@ -468,7 +468,10 @@ fn calculate_avocado_env_vars(
 
     // Set disk-specific environment variables if present on storage device
     if let Some(device_block_size) = device.block_size {
-        env_vars.insert("AVOCADO_DISK_BLOCK_SIZE".to_string(), device_block_size.to_string());
+        env_vars.insert(
+            "AVOCADO_DISK_BLOCK_SIZE".to_string(),
+            device_block_size.to_string(),
+        );
     }
     if let Some(device_uuid) = &device.uuid {
         env_vars.insert("AVOCADO_DISK_UUID".to_string(), device_uuid.clone());
@@ -485,11 +488,19 @@ fn calculate_avocado_env_vars(
                 // Input files are in the input directory
                 input_dir.join(filename).to_string_lossy().to_string()
             }
-            Image::Object { out, build_args: Some(_), .. } => {
+            Image::Object {
+                out,
+                build_args: Some(_),
+                ..
+            } => {
                 // Generated files (with build_args) are in the build directory
                 build_dir.join(out).to_string_lossy().to_string()
             }
-            Image::Object { out, build_args: None, .. } => {
+            Image::Object {
+                out,
+                build_args: None,
+                ..
+            } => {
                 // Object files without build_args are input files in the input directory
                 input_dir.join(out).to_string_lossy().to_string()
             }

--- a/src/commands/stone/provision.rs
+++ b/src/commands/stone/provision.rs
@@ -64,25 +64,25 @@ pub fn provision_command(input_dir: &Path, verbose: bool) -> Result<(), String> 
     for (device_name, device) in &manifest.storage_devices {
         log_info(&format!("Provisioning storage device '{device_name}'."));
 
-        // Build storage device if it has fwup build args
-        if let Some(build_args) = &device.build_args {
-            build_storage_device(
+        // First, build all images in the device (inner dependencies)
+        for (image_name, image) in &device.images {
+            build_image(
                 device_name,
-                device,
-                build_args,
-                &manifest,
+                image_name,
+                image,
                 input_dir,
                 &build_dir,
                 verbose,
             )?;
         }
 
-        // Process each image in the device
-        for (image_name, image) in &device.images {
-            build_image(
+        // Then, build storage device if it has fwup build args (outer dependencies)
+        if let Some(build_args) = &device.build_args {
+            build_storage_device(
                 device_name,
-                image_name,
-                image,
+                device,
+                build_args,
+                &manifest,
                 input_dir,
                 &build_dir,
                 verbose,

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -303,7 +303,10 @@ mod tests {
         };
 
         assert_eq!(image_with_disk_info.block_size(), Some(4096));
-        assert_eq!(image_with_disk_info.uuid(), Some("12345678-1234-1234-1234-123456789abc"));
+        assert_eq!(
+            image_with_disk_info.uuid(),
+            Some("12345678-1234-1234-1234-123456789abc")
+        );
 
         // Test Image::Object without block_size and uuid
         let image_without_disk_info = Image::Object {

--- a/tests/commands/stone/create/mod.rs
+++ b/tests/commands/stone/create/mod.rs
@@ -24,7 +24,10 @@ fn test_create() {
 
     // Check that only string-type images were copied
     // image_1 is an Image::Object with "out" field, so it should NOT be copied during create
-    assert!(!output_path.join("image_1").exists(), "image_1 should not be copied as it's an Image::Object that will be generated");
+    assert!(
+        !output_path.join("image_1").exists(),
+        "image_1 should not be copied as it's an Image::Object that will be generated"
+    );
     // image_2 is an Image::String, so it should be copied
     assert!(output_path.join("image_2").exists());
 
@@ -45,8 +48,14 @@ fn test_create() {
     // The string image files should be copied as-is (not built into FAT)
     // since create command only stages files
     // But object images with "out" field should not be copied
-    assert!(!output_path.join("image_1").exists(), "image_1 should not be copied as it's an Image::Object");
-    assert!(output_path.join("image_2").exists(), "image_2 should be copied as it's an Image::String");
+    assert!(
+        !output_path.join("image_1").exists(),
+        "image_1 should not be copied as it's an Image::Object"
+    );
+    assert!(
+        output_path.join("image_2").exists(),
+        "image_2 should be copied as it's an Image::String"
+    );
 }
 
 #[test]

--- a/tests/commands/stone/create/mod.rs
+++ b/tests/commands/stone/create/mod.rs
@@ -22,8 +22,10 @@ fn test_create() {
         .assert()
         .success();
 
-    // Check that the images were created
-    assert!(output_path.join("image_1").exists());
+    // Check that only string-type images were copied
+    // image_1 is an Image::Object with "out" field, so it should NOT be copied during create
+    assert!(!output_path.join("image_1").exists(), "image_1 should not be copied as it's an Image::Object that will be generated");
+    // image_2 is an Image::String, so it should be copied
     assert!(output_path.join("image_2").exists());
 
     // Check that the fwup template file was copied
@@ -40,10 +42,11 @@ fn test_create() {
     assert!(output_path.join("subdir/file_2").exists());
     assert!(!output_path.join("foo/file_2").exists());
 
-    // The image files should be copied as-is (not built into FAT)
+    // The string image files should be copied as-is (not built into FAT)
     // since create command only stages files
-    assert!(output_path.join("image_1").exists());
-    assert!(output_path.join("image_2").exists());
+    // But object images with "out" field should not be copied
+    assert!(!output_path.join("image_1").exists(), "image_1 should not be copied as it's an Image::Object");
+    assert!(output_path.join("image_2").exists(), "image_2 should be copied as it's an Image::String");
 }
 
 #[test]
@@ -153,4 +156,94 @@ fn test_create_with_provision_file() {
 
     // Check that the image file was copied
     assert!(output_path.join("simple.img").exists());
+}
+
+#[test]
+fn test_create_skips_object_images_with_out_field() {
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = temp_dir.path().join("input");
+    let output_path = temp_dir.path().join("output");
+
+    fs::create_dir_all(&input_path).unwrap();
+    fs::create_dir_all(&output_path).unwrap();
+
+    // Create a manifest with both Image::String and Image::Object types
+    let manifest_content = r#"{
+        "runtime": {
+            "platform": "test-platform",
+            "architecture": "noarch"
+        },
+        "storage_devices": {
+            "test_device": {
+                "out": "test.img",
+                "devpath": "/dev/test",
+                "images": {
+                    "string_image": "existing_file.img",
+                    "object_image": {
+                        "out": "generated_file.img",
+                        "size": 64,
+                        "size_unit": "mebibytes",
+                        "build_args": {
+                            "type": "fat",
+                            "variant": "FAT32",
+                            "files": [
+                                "input_file.txt"
+                            ]
+                        }
+                    }
+                },
+                "partitions": []
+            }
+        }
+    }"#;
+
+    let manifest_path = input_path.join("manifest.json");
+    fs::write(&manifest_path, manifest_content).unwrap();
+
+    // Create the files that should exist
+    fs::write(input_path.join("existing_file.img"), "existing content").unwrap();
+    fs::write(input_path.join("input_file.txt"), "file content").unwrap();
+    fs::write(input_path.join("os-release"), "NAME=Test\nVERSION_ID=1.0").unwrap();
+
+    // Note: We intentionally do NOT create "generated_file.img" since it should be generated during provision
+
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "create",
+            "--manifest-path",
+            &manifest_path.to_string_lossy(),
+            "--os-release",
+            &input_path.join("os-release").to_string_lossy(),
+            "--output-dir",
+            &output_path.to_string_lossy(),
+            "--input-dir",
+            &input_path.to_string_lossy(),
+        ])
+        .assert()
+        .success();
+
+    // Verify that Image::String files are copied
+    assert!(
+        output_path.join("existing_file.img").exists(),
+        "Image::String files should be copied during create"
+    );
+
+    // Verify that Image::Object files with "out" field are NOT copied
+    assert!(
+        !output_path.join("generated_file.img").exists(),
+        "Image::Object files with 'out' field should NOT be copied during create - they will be generated during provision"
+    );
+
+    // Verify that individual files within Image::Object are copied for building
+    assert!(
+        output_path.join("input_file.txt").exists(),
+        "Individual files specified in Image::Object build_args should be copied for later use during provision"
+    );
+
+    // Verify standard files are copied
+    assert!(output_path.join("manifest.json").exists());
+    assert!(output_path.join("os-release").exists());
 }

--- a/tests/commands/stone/provision/mod.rs
+++ b/tests/commands/stone/provision/mod.rs
@@ -440,7 +440,11 @@ fn test_provision_builds_images_before_storage_device() {
 
     // Create test files
     fs::write(input_path.join("boot_file.txt"), "Boot content").unwrap();
-    fs::write(input_path.join("fwup_template.conf"), "# Dummy fwup template").unwrap();
+    fs::write(
+        input_path.join("fwup_template.conf"),
+        "# Dummy fwup template",
+    )
+    .unwrap();
 
     // Create os-release file
     let os_release_content = r#"NAME="Avocado Linux"
@@ -520,7 +524,10 @@ VENDOR_NAME="Avocado Linux""#;
 
     // Both should be present, and image should come before storage device
     assert!(building_image_pos.is_some(), "Should log building image");
-    assert!(building_storage_pos.is_some(), "Should log building storage device");
+    assert!(
+        building_storage_pos.is_some(),
+        "Should log building storage device"
+    );
     assert!(
         building_image_pos.unwrap() < building_storage_pos.unwrap(),
         "Images should be built before storage device. Image build at {}, Storage build at {}",
@@ -639,22 +646,31 @@ task complete {
     // The paths should be absolute, not relative filenames
 
     // Check that AVOCADO_IMAGE_STRING_IMAGE points to input directory
-    let string_image_env = format!("AVOCADO_IMAGE_STRING_IMAGE={}", input_path.join("simple.img").display());
-        assert!(
+    let string_image_env = format!(
+        "AVOCADO_IMAGE_STRING_IMAGE={}",
+        input_path.join("simple.img").display()
+    );
+    assert!(
         stdout.contains(&string_image_env),
         "String image should point to input directory. Expected '{string_image_env}' in output"
     );
 
     // Check that AVOCADO_IMAGE_GENERATED_IMAGE points to build directory
-    let generated_image_env = format!("AVOCADO_IMAGE_GENERATED_IMAGE={}", input_path.join("_build").join("generated.img").display());
-        assert!(
+    let generated_image_env = format!(
+        "AVOCADO_IMAGE_GENERATED_IMAGE={}",
+        input_path.join("_build").join("generated.img").display()
+    );
+    assert!(
         stdout.contains(&generated_image_env),
         "Generated image should point to build directory. Expected '{generated_image_env}' in output"
     );
 
     // Check that AVOCADO_IMAGE_OBJECT_NO_BUILD points to input directory (no build_args)
-    let object_image_env = format!("AVOCADO_IMAGE_OBJECT_NO_BUILD={}", input_path.join("object_input.img").display());
-        assert!(
+    let object_image_env = format!(
+        "AVOCADO_IMAGE_OBJECT_NO_BUILD={}",
+        input_path.join("object_input.img").display()
+    );
+    assert!(
         stdout.contains(&object_image_env),
         "Object image without build_args should point to input directory. Expected '{object_image_env}' in output"
     );
@@ -748,18 +764,21 @@ task complete {
     // Check that the disk-specific environment variables are logged
     // The verbose output should show these environment variables when building the fwup image
     assert!(
-        stdout.contains("AVOCADO_DISK_BLOCK_SIZE=4096") || stderr.contains("AVOCADO_DISK_BLOCK_SIZE=4096"),
+        stdout.contains("AVOCADO_DISK_BLOCK_SIZE=4096")
+            || stderr.contains("AVOCADO_DISK_BLOCK_SIZE=4096"),
         "Should log AVOCADO_DISK_BLOCK_SIZE environment variable. Stdout: {stdout}, Stderr: {stderr}"
     );
 
     assert!(
-        stdout.contains("AVOCADO_DISK_UUID=12345678-1234-1234-1234-123456789abc") || stderr.contains("AVOCADO_DISK_UUID=12345678-1234-1234-1234-123456789abc"),
+        stdout.contains("AVOCADO_DISK_UUID=12345678-1234-1234-1234-123456789abc")
+            || stderr.contains("AVOCADO_DISK_UUID=12345678-1234-1234-1234-123456789abc"),
         "Should log AVOCADO_DISK_UUID environment variable. Stdout: {stdout}, Stderr: {stderr}"
     );
 
     // Check that we're building the correct fwup image
     assert!(
-        stdout.contains("Building fwup image 'fwup_image'") || stderr.contains("Building fwup image 'fwup_image'"),
+        stdout.contains("Building fwup image 'fwup_image'")
+            || stderr.contains("Building fwup image 'fwup_image'"),
         "Should be building the fwup image"
     );
 }
@@ -837,7 +856,8 @@ task complete {
 
     // Check that the disk-specific environment variables are NOT logged when not present
     assert!(
-        !stdout.contains("AVOCADO_DISK_BLOCK_SIZE=") && !stderr.contains("AVOCADO_DISK_BLOCK_SIZE="),
+        !stdout.contains("AVOCADO_DISK_BLOCK_SIZE=")
+            && !stderr.contains("AVOCADO_DISK_BLOCK_SIZE="),
         "Should not log AVOCADO_DISK_BLOCK_SIZE when not present in manifest"
     );
 
@@ -848,7 +868,8 @@ task complete {
 
     // Check that we're still building the fwup image
     assert!(
-        stdout.contains("Building fwup image 'fwup_image'") || stderr.contains("Building fwup image 'fwup_image'"),
+        stdout.contains("Building fwup image 'fwup_image'")
+            || stderr.contains("Building fwup image 'fwup_image'"),
         "Should be building the fwup image"
     );
 }
@@ -943,18 +964,21 @@ task complete {
 
     // Check that the storage device disk-specific environment variables are logged
     assert!(
-        stdout.contains("AVOCADO_DISK_BLOCK_SIZE=512") || stderr.contains("AVOCADO_DISK_BLOCK_SIZE=512"),
+        stdout.contains("AVOCADO_DISK_BLOCK_SIZE=512")
+            || stderr.contains("AVOCADO_DISK_BLOCK_SIZE=512"),
         "Should log AVOCADO_DISK_BLOCK_SIZE from storage device. Stdout: {stdout}, Stderr: {stderr}"
     );
 
     assert!(
-        stdout.contains("AVOCADO_DISK_UUID=4bc367b3-5d70-4289-b24d-9b09cb79685c") || stderr.contains("AVOCADO_DISK_UUID=4bc367b3-5d70-4289-b24d-9b09cb79685c"),
+        stdout.contains("AVOCADO_DISK_UUID=4bc367b3-5d70-4289-b24d-9b09cb79685c")
+            || stderr.contains("AVOCADO_DISK_UUID=4bc367b3-5d70-4289-b24d-9b09cb79685c"),
         "Should log AVOCADO_DISK_UUID from storage device. Stdout: {stdout}, Stderr: {stderr}"
     );
 
     // Check that we're building the storage device
     assert!(
-        stdout.contains("Building storage device 'rootdisk'") || stderr.contains("Building storage device 'rootdisk'"),
+        stdout.contains("Building storage device 'rootdisk'")
+            || stderr.contains("Building storage device 'rootdisk'"),
         "Should be building the rootdisk storage device"
     );
 

--- a/tests/commands/stone/provision/mod.rs
+++ b/tests/commands/stone/provision/mod.rs
@@ -45,13 +45,13 @@ fn test_provision_creates_build_dir() {
     fs::write(input_path.join("simple.img"), "test content").unwrap();
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     Command::cargo_bin("stone")
@@ -78,13 +78,13 @@ fn test_provision_fat_image_without_fwup() {
     fs::write(input_path.join("test_file.txt"), "Hello, FAT!").unwrap();
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest with just a FAT image (no fwup required)
@@ -119,13 +119,13 @@ VENDOR_NAME="Test Corporation""#;
     fs::write(input_path.join("manifest.json"), manifest_content).unwrap();
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     let result = Command::cargo_bin("stone")
@@ -188,13 +188,13 @@ fn test_provision_unsupported_size_unit() {
     fs::write(input_path.join("manifest.json"), manifest_content).unwrap();
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     Command::cargo_bin("stone")
@@ -273,10 +273,10 @@ fn test_provision_invalid_os_release() {
     fs::write(input_path.join("test.conf"), "# Dummy fwup config").unwrap();
 
     // Create os-release file without VERSION_ID
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
-PRETTY_NAME="Test Linux 1.0.0""#;
+ID=avocado
+PRETTY_NAME="Avocado Linux 1.0.0""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     Command::cargo_bin("stone")
@@ -335,13 +335,13 @@ exit 0
     }
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     Command::cargo_bin("stone")
@@ -414,13 +414,13 @@ exit 1
     }
 
     // Create os-release file for AVOCADO_OS_VERSION
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     Command::cargo_bin("stone")
@@ -443,13 +443,13 @@ fn test_provision_builds_images_before_storage_device() {
     fs::write(input_path.join("fwup_template.conf"), "# Dummy fwup template").unwrap();
 
     // Create os-release file
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest that has both FAT images and fwup storage device
@@ -539,13 +539,13 @@ fn test_provision_env_vars_use_full_paths() {
     fs::write(input_path.join("simple.img"), "Simple image content").unwrap();
 
     // Create os-release file
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest with mixed image types to test path resolution
@@ -593,8 +593,8 @@ VENDOR_NAME="Test Corporation""#;
     // Create a minimal fwup template that will at least parse
     let fwup_template = r#"
 # Minimal fwup template for testing
-meta-product = "Test Product"
-meta-description = "Test Description"
+meta-product = "Avocado Test Image"
+meta-description = "Generic test image for Avocado"
 meta-version = "1.0.0"
 
 # Define resources that reference the environment variables
@@ -672,13 +672,13 @@ fn test_provision_fwup_image_with_disk_env_vars() {
     let input_path = temp_dir.path();
 
     // Create os-release file
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest with a fwup image that has block_size and uuid
@@ -714,8 +714,8 @@ VENDOR_NAME="Test Corporation""#;
     // Create a minimal fwup template
     let fwup_template = r#"
 # Minimal fwup template for testing
-meta-product = "Test Product"
-meta-description = "Test Description"
+meta-product = "Avocado Test Image"
+meta-description = "Generic test image for Avocado"
 meta-version = "1.0.0"
 
 # Define a resource that would use the disk environment variables
@@ -770,13 +770,13 @@ fn test_provision_fwup_image_without_disk_env_vars() {
     let input_path = temp_dir.path();
 
     // Create os-release file
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest with a fwup image that does NOT have block_size and uuid
@@ -810,8 +810,8 @@ VENDOR_NAME="Test Corporation""#;
     // Create a minimal fwup template
     let fwup_template = r#"
 # Minimal fwup template for testing
-meta-product = "Test Product"
-meta-description = "Test Description"
+meta-product = "Avocado Test Image"
+meta-description = "Generic test image for Avocado"
 meta-version = "1.0.0"
 
 task complete {
@@ -862,20 +862,20 @@ fn test_provision_storage_device_with_disk_env_vars() {
     fs::write(input_path.join("boot_file.txt"), "Boot content").unwrap();
 
     // Create os-release file
-    let os_release_content = r#"NAME="Test Linux"
+    let os_release_content = r#"NAME="Avocado Linux"
 VERSION="1.0.0"
-ID=testlinux
+ID=avocado
 VERSION_ID="1.0.0"
-VERSION_CODENAME=jammy
-PRETTY_NAME="Test Linux 1.0.0"
-VENDOR_NAME="Test Corporation""#;
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+VENDOR_NAME="Avocado Linux""#;
     fs::write(input_path.join("os-release"), os_release_content).unwrap();
 
     // Create a manifest with storage device that has block_size and uuid (like your imx93 example)
     let manifest_content = r#"{
         "runtime": {
-            "platform": "test-platform",
-            "architecture": "arm64"
+            "platform": "generic-platform",
+            "architecture": "test-arch"
         },
         "storage_devices": {
             "rootdisk": {
@@ -884,7 +884,7 @@ VENDOR_NAME="Test Corporation""#;
                     "type": "fwup",
                     "template": "rootdisk.conf"
                 },
-                "devpath": "/dev/mmcblk1",
+                "devpath": "/dev/generic",
                 "block_size": 512,
                 "uuid": "4bc367b3-5d70-4289-b24d-9b09cb79685c",
                 "images": {
@@ -911,8 +911,8 @@ VENDOR_NAME="Test Corporation""#;
     // Create a minimal fwup template
     let fwup_template = r#"
 # Minimal fwup template for testing storage device
-meta-product = "Test Product"
-meta-description = "Test Description"
+meta-product = "Avocado Test Image"
+meta-description = "Generic test image for Avocado"
 meta-version = "1.0.0"
 
 # Example of how fwup template would use the disk environment variables


### PR DESCRIPTION
* Fixed issue with create where it was attempting to validate and copy in "out" files for image / storage device builds that do not exist yet.
* Ensure that the deepest nested images are build first and work ourwards on provision
* pass absolute paths to images instead of passing AVOCADO_SDK_RUNTIME_DIR and basing image paths in the rootdisk.conf. This allows the boot.img file and any other build files to be located in _build instead of only the data dir. 
* Add support for setting `AVOCADO_DISK_UUID` and `AVOCADO_DISK_BLOCK_SIZE` from their respective "image object" top level keys `uuid` and `block_size`

tested on meta-avocado nxp / raspberry pi / qemu target families 