### PR TITLE
Release 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "9d26fcce2f397e5488affdf681b20c030aa9faa877b92b1825e5d66b08d2fc33"
 
 [[package]]
 name = "stone"
-version = "2.0.0"
+version = "2.1.0"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stone"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2024"
 description = "A CLI for managing Avocado stones."
 homepage = "https://github.com/avocado-linux/stone"

--- a/src/commands/stone/validate.rs
+++ b/src/commands/stone/validate.rs
@@ -69,12 +69,26 @@ pub fn validate_command(manifest_path: &Path, input_dirs: &[PathBuf]) -> Result<
         ));
     }
 
+    // Known values for the provision profile `requires` field
+    const KNOWN_REQUIRES: &[&str] = &["usb"];
+
     // Check provision profiles and their scripts
     if let Some(provision) = &manifest.provision {
         for (profile_name, profile) in &provision.profiles {
             if find_file_in_dirs(&profile.script, input_dirs).is_none() {
                 missing_provision_files
                     .push((format!("Profile '{profile_name}'"), profile.script.clone()));
+            }
+            for req in &profile.requires {
+                if !KNOWN_REQUIRES.contains(&req.as_str()) {
+                    missing_provision_files.push((
+                        format!("Profile '{profile_name}'"),
+                        format!(
+                            "Unknown requires value '{req}'. Known values: {}",
+                            KNOWN_REQUIRES.join(", ")
+                        ),
+                    ));
+                }
             }
         }
 

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -157,6 +157,11 @@ pub struct ProvisionProfile {
     pub script: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub envs: Option<Vec<ProvisionEnv>>,
+    /// Declares capabilities this profile requires from the host environment.
+    /// Known values: "usb" (USB device passthrough for direct device flashing).
+    /// Scripts should check AVOCADO_USB_PASSTHROUGH env var to adapt at runtime.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub requires: Vec<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]


### PR DESCRIPTION
## Summary
- Add `requires` field to `ProvisionProfile` for declaring host capability requirements (e.g., `"usb"` for device passthrough)
- Validate `requires` values against known set in `stone validate`
- Bump version to 2.1.0

## Context
Supports Docker Desktop SD card provisioning: profiles can now declare they need USB passthrough, enabling tooling to adapt when running in environments without device access.