### PR TITLE
chore: release 2.1.1 — provision.files for extra helper scripts

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -647,7 +647,7 @@ checksum = "9d26fcce2f397e5488affdf681b20c030aa9faa877b92b1825e5d66b08d2fc33"
 
 [[package]]
 name = "stone"
-version = "2.1.0"
+version = "2.1.1"
 dependencies = [
  "assert_cmd",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stone"
-version = "2.1.0"
+version = "2.1.1"
 edition = "2024"
 description = "A CLI for managing Avocado stones."
 homepage = "https://github.com/avocado-linux/stone"

--- a/src/commands/stone/bundle.rs
+++ b/src/commands/stone/bundle.rs
@@ -244,7 +244,11 @@ fn copy_manifest_inputs(
     let manifest_dest = build_dir.join("manifest.json");
     if let Some(json_str) = merged_manifest_json {
         fs::write(&manifest_dest, json_str).map_err(|e| {
-            format!("Failed to write merged manifest to '{}': {}", manifest_dest.display(), e)
+            format!(
+                "Failed to write merged manifest to '{}': {}",
+                manifest_dest.display(),
+                e
+            )
         })?;
     } else {
         copy_file(manifest_path, &manifest_dest, verbose)?;

--- a/src/commands/stone/bundle.rs
+++ b/src/commands/stone/bundle.rs
@@ -50,6 +50,10 @@ pub struct BundleArgs {
     #[arg(long = "build-dir", value_name = "DIR")]
     pub build_dir: Option<PathBuf>,
 
+    /// Overlay files to deep-merge onto the base manifest (applied left-to-right)
+    #[arg(long = "overlay", value_name = "PATH")]
+    pub overlays: Vec<PathBuf>,
+
     /// Enable verbose output
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
@@ -64,6 +68,7 @@ impl BundleArgs {
             &self.input_dirs,
             &self.output,
             self.build_dir.as_deref(),
+            &self.overlays,
             self.verbose,
         )
     }
@@ -98,6 +103,7 @@ fn sha256_file(path: &Path) -> Result<String, String> {
     Ok(format!("{:x}", hasher.finalize()))
 }
 
+#[allow(clippy::too_many_arguments)]
 pub fn bundle_command(
     manifest_path: &Path,
     os_release_path: &Path,
@@ -105,6 +111,7 @@ pub fn bundle_command(
     input_dirs: &[PathBuf],
     output_path: &Path,
     build_dir_override: Option<&Path>,
+    overlay_paths: &[PathBuf],
     verbose: bool,
 ) -> Result<(), String> {
     // Validate inputs exist
@@ -121,7 +128,7 @@ pub fn bundle_command(
         ));
     }
 
-    let manifest = Manifest::from_file(manifest_path)?;
+    let (manifest, merged_json) = Manifest::load_and_merge(manifest_path, overlay_paths)?;
 
     // Determine build directory
     let default_build_dir = output_path
@@ -162,6 +169,7 @@ pub fn bundle_command(
         os_release_initrd_path,
         input_dirs,
         build_dir,
+        merged_json.as_deref(),
         verbose,
     )?;
 
@@ -221,6 +229,7 @@ struct BundleArtifact {
 }
 
 /// Copy manifest inputs to the build directory (mirrors stone create behavior)
+#[allow(clippy::too_many_arguments)]
 fn copy_manifest_inputs(
     manifest: &Manifest,
     manifest_path: &Path,
@@ -228,11 +237,18 @@ fn copy_manifest_inputs(
     os_release_initrd_path: Option<&Path>,
     input_dirs: &[PathBuf],
     build_dir: &Path,
+    merged_manifest_json: Option<&str>,
     verbose: bool,
 ) -> Result<(), String> {
-    // Copy the manifest itself
+    // Write the manifest — merged JSON when overlays were applied, or copy original
     let manifest_dest = build_dir.join("manifest.json");
-    copy_file(manifest_path, &manifest_dest, verbose)?;
+    if let Some(json_str) = merged_manifest_json {
+        fs::write(&manifest_dest, json_str).map_err(|e| {
+            format!("Failed to write merged manifest to '{}': {}", manifest_dest.display(), e)
+        })?;
+    } else {
+        copy_file(manifest_path, &manifest_dest, verbose)?;
+    }
 
     // Copy os-release
     let os_release_dest = build_dir.join("os-release");

--- a/src/commands/stone/bundle.rs
+++ b/src/commands/stone/bundle.rs
@@ -302,11 +302,16 @@ fn copy_manifest_inputs(
         copy_file(&src, &build_dir.join(provision_file), verbose)?;
     }
 
-    // Copy provision profile scripts
+    // Copy provision profile scripts and extra files
     if let Some(provision) = &manifest.provision {
         for profile in provision.profiles.values() {
             if let Some(src) = find_file_in_dirs(&profile.script, input_dirs) {
                 copy_file(&src, &build_dir.join(&profile.script), verbose)?;
+            }
+        }
+        for file in &provision.files {
+            if let Some(src) = find_file_in_dirs(file, input_dirs) {
+                copy_file(&src, &build_dir.join(file), verbose)?;
             }
         }
     }

--- a/src/commands/stone/create.rs
+++ b/src/commands/stone/create.rs
@@ -169,7 +169,7 @@ pub fn create_command(
         }
     }
 
-    // Copy provision profile scripts
+    // Copy provision profile scripts and extra files
     if let Some(provision) = &manifest.provision {
         for (profile_name, profile) in &provision.profiles {
             match find_file_in_dirs(&profile.script, input_dirs) {
@@ -186,6 +186,23 @@ pub fn create_command(
                     errors.push(format!(
                         "Failed to copy provision profile script '{}' for profile '{profile_name}': not found in any input directory",
                         profile.script
+                    ));
+                }
+            }
+        }
+
+        // Copy extra provision files (shared helpers, common libraries)
+        for file in &provision.files {
+            match find_file_in_dirs(file, input_dirs) {
+                Some(src) => {
+                    let dest = output_dir.join(file);
+                    if let Err(e) = copy_file(&src, &dest, verbose) {
+                        errors.push(format!("Failed to copy provision file '{file}': {e}"));
+                    }
+                }
+                None => {
+                    errors.push(format!(
+                        "Failed to copy provision file '{file}': not found in any input directory"
                     ));
                 }
             }

--- a/src/commands/stone/create.rs
+++ b/src/commands/stone/create.rs
@@ -37,6 +37,10 @@ pub struct CreateArgs {
     )]
     pub output_dir: PathBuf,
 
+    /// Overlay files to deep-merge onto the base manifest (applied left-to-right)
+    #[arg(long = "overlay", value_name = "PATH")]
+    pub overlays: Vec<PathBuf>,
+
     /// Enable verbose output
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
@@ -49,6 +53,7 @@ impl CreateArgs {
             &self.os_release,
             &self.input_dirs,
             &self.output_dir,
+            &self.overlays,
             self.verbose,
         )
     }
@@ -70,6 +75,7 @@ pub fn create_command(
     os_release_path: &Path,
     input_dirs: &[PathBuf],
     output_dir: &PathBuf,
+    overlay_paths: &[PathBuf],
     verbose: bool,
 ) -> Result<(), String> {
     // Check if manifest file exists
@@ -88,7 +94,7 @@ pub fn create_command(
         ));
     }
 
-    let manifest = Manifest::from_file(manifest_path)?;
+    let (manifest, merged_json) = Manifest::load_and_merge(manifest_path, overlay_paths)?;
 
     // Ensure output directory exists
     if let Err(e) = fs::create_dir_all(output_dir) {
@@ -186,9 +192,19 @@ pub fn create_command(
         }
     }
 
-    // Copy the manifest file to the output directory as manifest.json
+    // Write the manifest to the output directory — merged JSON when overlays
+    // are present, or a byte-for-byte copy of the original otherwise
     let manifest_output_path = output_dir.join("manifest.json");
-    if let Err(e) = copy_file(manifest_path, &manifest_output_path, verbose) {
+    if let Some(json_str) = &merged_json {
+        if let Err(e) = fs::write(&manifest_output_path, json_str) {
+            errors.push(format!("Failed to write merged manifest: {e}"));
+        } else if verbose {
+            log_debug(&format!(
+                "Wrote merged manifest to '{}'",
+                manifest_output_path.display()
+            ));
+        }
+    } else if let Err(e) = copy_file(manifest_path, &manifest_output_path, verbose) {
         errors.push(format!(
             "Failed to copy manifest file '{}': {e}",
             manifest_path.display()

--- a/src/commands/stone/describe_manifest.rs
+++ b/src/commands/stone/describe_manifest.rs
@@ -13,15 +13,22 @@ pub struct DescribeManifestArgs {
         default_value = "manifest.json"
     )]
     pub manifest: PathBuf,
+
+    /// Overlay files to deep-merge onto the base manifest (applied left-to-right)
+    #[arg(long = "overlay", value_name = "PATH")]
+    pub overlays: Vec<PathBuf>,
 }
 
 impl DescribeManifestArgs {
     pub fn execute(&self) -> Result<(), String> {
-        describe_manifest_command(&self.manifest)
+        describe_manifest_command(&self.manifest, &self.overlays)
     }
 }
 
-pub fn describe_manifest_command(manifest_path: &Path) -> Result<(), String> {
+pub fn describe_manifest_command(
+    manifest_path: &Path,
+    overlay_paths: &[PathBuf],
+) -> Result<(), String> {
     // Check if manifest file exists
     if !manifest_path.exists() {
         return Err(format!(
@@ -30,7 +37,7 @@ pub fn describe_manifest_command(manifest_path: &Path) -> Result<(), String> {
         ));
     }
 
-    let manifest = Manifest::from_file(manifest_path)?;
+    let manifest = Manifest::from_file_with_overlays(manifest_path, overlay_paths)?;
     describe_manifest(&manifest)?;
     log_success("Described manifest.");
     Ok(())

--- a/src/commands/stone/provision.rs
+++ b/src/commands/stone/provision.rs
@@ -20,6 +20,10 @@ pub struct ProvisionArgs {
     )]
     pub input_dirs: Vec<PathBuf>,
 
+    /// Overlay files to deep-merge onto the base manifest (applied left-to-right)
+    #[arg(long = "overlay", value_name = "PATH")]
+    pub overlays: Vec<PathBuf>,
+
     /// Enable verbose output
     #[arg(short = 'v', long = "verbose")]
     pub verbose: bool,
@@ -27,7 +31,7 @@ pub struct ProvisionArgs {
 
 impl ProvisionArgs {
     pub fn execute(&self) -> Result<(), String> {
-        provision_command(&self.input_dirs, self.verbose)
+        provision_command(&self.input_dirs, &self.overlays, self.verbose)
     }
 }
 
@@ -42,13 +46,17 @@ fn find_file_in_dirs(filename: &str, input_dirs: &[PathBuf]) -> Option<PathBuf> 
     None
 }
 
-pub fn provision_command(input_dirs: &[PathBuf], verbose: bool) -> Result<(), String> {
+pub fn provision_command(
+    input_dirs: &[PathBuf],
+    overlay_paths: &[PathBuf],
+    verbose: bool,
+) -> Result<(), String> {
     // Find manifest.json in the input directories
     let manifest_path = find_file_in_dirs("manifest.json", input_dirs).ok_or_else(|| {
         "Manifest file 'manifest.json' not found in any input directory.".to_string()
     })?;
 
-    let manifest = Manifest::from_file(&manifest_path)?;
+    let manifest = Manifest::from_file_with_overlays(&manifest_path, overlay_paths)?;
 
     // Determine the directory containing the manifest
     let input_dir = manifest_path

--- a/src/commands/stone/validate.rs
+++ b/src/commands/stone/validate.rs
@@ -23,11 +23,15 @@ pub struct ValidateArgs {
         default_value = "."
     )]
     pub input_dirs: Vec<PathBuf>,
+
+    /// Overlay files to deep-merge onto the base manifest (applied left-to-right)
+    #[arg(long = "overlay", value_name = "PATH")]
+    pub overlays: Vec<PathBuf>,
 }
 
 impl ValidateArgs {
     pub fn execute(&self) -> Result<(), String> {
-        validate_command(&self.manifest, &self.input_dirs)
+        validate_command(&self.manifest, &self.input_dirs, &self.overlays)
     }
 }
 
@@ -42,7 +46,11 @@ fn find_file_in_dirs(filename: &str, input_dirs: &[PathBuf]) -> Option<PathBuf> 
     None
 }
 
-pub fn validate_command(manifest_path: &Path, input_dirs: &[PathBuf]) -> Result<(), String> {
+pub fn validate_command(
+    manifest_path: &Path,
+    input_dirs: &[PathBuf],
+    overlay_paths: &[PathBuf],
+) -> Result<(), String> {
     // Check if manifest file exists
     if !manifest_path.exists() {
         return Err(format!(
@@ -51,7 +59,7 @@ pub fn validate_command(manifest_path: &Path, input_dirs: &[PathBuf]) -> Result<
         ));
     }
 
-    let manifest = Manifest::from_file(manifest_path)?;
+    let manifest = Manifest::from_file_with_overlays(manifest_path, overlay_paths)?;
 
     // Validate all files referenced in the manifest
     let mut missing_files = Vec::new();

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -394,10 +394,8 @@ impl Manifest {
             deep_merge_json(&mut merged, overlay_value);
         }
 
-        let merged_json =
-            serde_json::to_string_pretty(&merged).map_err(|e| {
-                format!("[ERROR] Failed to serialize merged manifest: {}", e)
-            })?;
+        let merged_json = serde_json::to_string_pretty(&merged)
+            .map_err(|e| format!("[ERROR] Failed to serialize merged manifest: {}", e))?;
 
         let manifest: Self = serde_json::from_value(merged).map_err(|e| {
             format!(
@@ -1087,8 +1085,14 @@ mod tests {
             }
         });
         deep_merge_json(&mut base, overlay);
-        assert_eq!(base["storage_devices"]["rootdisk"]["images"]["boot"]["out"], "boot.img");
-        assert_eq!(base["storage_devices"]["rootdisk"]["images"]["rootfs"], "rootfs.img");
+        assert_eq!(
+            base["storage_devices"]["rootdisk"]["images"]["boot"]["out"],
+            "boot.img"
+        );
+        assert_eq!(
+            base["storage_devices"]["rootdisk"]["images"]["rootfs"],
+            "rootfs.img"
+        );
     }
 
     #[test]
@@ -1209,7 +1213,10 @@ mod tests {
             }
         });
         deep_merge_json(&mut base, overlay);
-        assert_eq!(base["provision"]["profiles"]["img"]["script"], "provision.sh");
+        assert_eq!(
+            base["provision"]["profiles"]["img"]["script"],
+            "provision.sh"
+        );
         assert_eq!(base["runtime"]["platform"], "test");
     }
 
@@ -1247,8 +1254,7 @@ mod tests {
         std::fs::write(&base_path, base_json).unwrap();
         std::fs::write(&overlay_path, overlay_json).unwrap();
 
-        let manifest =
-            Manifest::from_file_with_overlays(&base_path, &[overlay_path]).unwrap();
+        let manifest = Manifest::from_file_with_overlays(&base_path, &[overlay_path]).unwrap();
 
         assert_eq!(manifest.runtime.platform, "overlay-platform");
         assert_eq!(manifest.runtime.architecture, "arm64");
@@ -1274,8 +1280,9 @@ mod tests {
         .unwrap();
         std::fs::write(&overlay_path, "not valid json{{{").unwrap();
 
-        let err = Manifest::from_file_with_overlays(&base_path, &[overlay_path.clone()])
-            .unwrap_err();
+        let err =
+            Manifest::from_file_with_overlays(&base_path, std::slice::from_ref(&overlay_path))
+                .unwrap_err();
         assert!(err.contains("Failed to parse overlay JSON"));
         assert!(err.contains("bad.json"));
     }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value;
 use std::collections::HashMap;
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -329,6 +330,83 @@ impl Manifest {
         })
     }
 
+    /// Load a manifest from a base file, then deep-merge each overlay file
+    /// on top in order (left-to-right, last wins). The merged JSON is then
+    /// deserialized into a typed `Manifest`.
+    pub fn from_file_with_overlays(
+        base_path: &std::path::Path,
+        overlay_paths: &[std::path::PathBuf],
+    ) -> Result<Self, String> {
+        if overlay_paths.is_empty() {
+            return Self::from_file(base_path);
+        }
+
+        let (manifest, _) = Self::load_and_merge(base_path, overlay_paths)?;
+        Ok(manifest)
+    }
+
+    /// Load a manifest with overlays, returning both the typed Manifest and
+    /// the pretty-printed merged JSON string (for commands that need to write
+    /// the merged manifest to disk).
+    pub fn load_and_merge(
+        base_path: &std::path::Path,
+        overlay_paths: &[std::path::PathBuf],
+    ) -> Result<(Self, Option<String>), String> {
+        if overlay_paths.is_empty() {
+            let manifest = Self::from_file(base_path)?;
+            return Ok((manifest, None));
+        }
+
+        let base_content = std::fs::read_to_string(base_path).map_err(|e| {
+            format!(
+                "[ERROR] Failed to read manifest file '{}': {}",
+                base_path.display(),
+                e
+            )
+        })?;
+        let mut merged: Value = serde_json::from_str(&base_content).map_err(|e| {
+            format!(
+                "[ERROR] Failed to parse manifest JSON '{}': {}",
+                base_path.display(),
+                e
+            )
+        })?;
+
+        for overlay_path in overlay_paths {
+            let overlay_content = std::fs::read_to_string(overlay_path).map_err(|e| {
+                format!(
+                    "[ERROR] Failed to read overlay file '{}': {}",
+                    overlay_path.display(),
+                    e
+                )
+            })?;
+            let overlay_value: Value = serde_json::from_str(&overlay_content).map_err(|e| {
+                format!(
+                    "[ERROR] Failed to parse overlay JSON '{}': {}",
+                    overlay_path.display(),
+                    e
+                )
+            })?;
+            deep_merge_json(&mut merged, overlay_value);
+        }
+
+        let merged_json =
+            serde_json::to_string_pretty(&merged).map_err(|e| {
+                format!("[ERROR] Failed to serialize merged manifest: {}", e)
+            })?;
+
+        let manifest: Self = serde_json::from_value(merged).map_err(|e| {
+            format!(
+                "[ERROR] Merged manifest (base '{}' + {} overlay(s)) is invalid: {}",
+                base_path.display(),
+                overlay_paths.len(),
+                e
+            )
+        })?;
+
+        Ok((manifest, Some(merged_json)))
+    }
+
     pub fn get_provision_profile(&self, profile_name: &str) -> Option<&ProvisionProfile> {
         self.provision.as_ref()?.profiles.get(profile_name)
     }
@@ -431,6 +509,47 @@ impl Provision {
         }
 
         (result, missing_vars)
+    }
+}
+
+/// Deep-merge two JSON values. Objects are merged recursively (overlay keys
+/// win on conflict). Arrays of named objects (elements with a `"name"` string
+/// field) are merged by matching names. All other values (scalars, unnamed
+/// arrays) in `overlay` replace `base` entirely.
+pub fn deep_merge_json(base: &mut Value, overlay: Value) {
+    match (base, overlay) {
+        (Value::Object(base_map), Value::Object(overlay_map)) => {
+            for (key, overlay_val) in overlay_map {
+                let entry = base_map.entry(key).or_insert(Value::Null);
+                deep_merge_json(entry, overlay_val);
+            }
+        }
+        (Value::Array(base_arr), Value::Array(overlay_arr)) => {
+            // Name-based merge: if all overlay elements are objects with "name" fields,
+            // match to base elements by name and deep-merge individually
+            let all_named = !overlay_arr.is_empty()
+                && overlay_arr
+                    .iter()
+                    .all(|v| v.get("name").and_then(|n| n.as_str()).is_some());
+            if all_named {
+                for overlay_elem in overlay_arr {
+                    let name = overlay_elem.get("name").unwrap().as_str().unwrap();
+                    if let Some(base_elem) = base_arr
+                        .iter_mut()
+                        .find(|b| b.get("name").and_then(|n| n.as_str()) == Some(name))
+                    {
+                        deep_merge_json(base_elem, overlay_elem);
+                    } else {
+                        base_arr.push(overlay_elem);
+                    }
+                }
+            } else {
+                *base_arr = overlay_arr;
+            }
+        }
+        (base, overlay) => {
+            *base = overlay;
+        }
     }
 }
 
@@ -917,5 +1036,287 @@ mod tests {
         assert!(manifest.get_provision_profile("profile1").is_some());
         assert!(manifest.get_provision_profile("nonexistent").is_none());
         assert_eq!(manifest.get_provision_default(), Some("default_profile"));
+    }
+
+    // --- deep_merge_json tests ---
+
+    #[test]
+    fn test_deep_merge_scalar_override() {
+        let mut base = serde_json::json!({"runtime": {"platform": "a", "architecture": "arm64"}});
+        let overlay = serde_json::json!({"runtime": {"platform": "b"}});
+        deep_merge_json(&mut base, overlay);
+        assert_eq!(base["runtime"]["platform"], "b");
+        assert_eq!(base["runtime"]["architecture"], "arm64");
+    }
+
+    #[test]
+    fn test_deep_merge_adds_new_keys() {
+        let mut base = serde_json::json!({"runtime": {"platform": "a"}});
+        let overlay = serde_json::json!({"runtime": {"architecture": "arm64"}});
+        deep_merge_json(&mut base, overlay);
+        assert_eq!(base["runtime"]["platform"], "a");
+        assert_eq!(base["runtime"]["architecture"], "arm64");
+    }
+
+    #[test]
+    fn test_deep_merge_nested_objects() {
+        let mut base = serde_json::json!({
+            "storage_devices": {
+                "rootdisk": {
+                    "images": {
+                        "boot": {"out": "boot.img", "size": 128}
+                    }
+                }
+            }
+        });
+        let overlay = serde_json::json!({
+            "storage_devices": {
+                "rootdisk": {
+                    "images": {
+                        "rootfs": "rootfs.img"
+                    }
+                }
+            }
+        });
+        deep_merge_json(&mut base, overlay);
+        assert_eq!(base["storage_devices"]["rootdisk"]["images"]["boot"]["out"], "boot.img");
+        assert_eq!(base["storage_devices"]["rootdisk"]["images"]["rootfs"], "rootfs.img");
+    }
+
+    #[test]
+    fn test_deep_merge_named_array_merge_by_name() {
+        let mut base = serde_json::json!({
+            "partitions": [
+                {"name": "boot", "size": 128, "size_unit": "mebibytes"},
+                {"name": "var", "size": 512, "size_unit": "mebibytes", "expand": "true"}
+            ]
+        });
+        let overlay = serde_json::json!({
+            "partitions": [
+                {"name": "var", "size": 1024}
+            ]
+        });
+        deep_merge_json(&mut base, overlay);
+
+        let partitions = base["partitions"].as_array().unwrap();
+        assert_eq!(partitions.len(), 2);
+        // boot unchanged
+        assert_eq!(partitions[0]["name"], "boot");
+        assert_eq!(partitions[0]["size"], 128);
+        // var merged — size changed, other fields preserved
+        assert_eq!(partitions[1]["name"], "var");
+        assert_eq!(partitions[1]["size"], 1024);
+        assert_eq!(partitions[1]["size_unit"], "mebibytes");
+        assert_eq!(partitions[1]["expand"], "true");
+    }
+
+    #[test]
+    fn test_deep_merge_named_array_appends_new() {
+        let mut base = serde_json::json!({
+            "partitions": [
+                {"name": "boot", "size": 128, "size_unit": "mebibytes"}
+            ]
+        });
+        let overlay = serde_json::json!({
+            "partitions": [
+                {"name": "data", "size": 2048, "size_unit": "mebibytes"}
+            ]
+        });
+        deep_merge_json(&mut base, overlay);
+
+        let partitions = base["partitions"].as_array().unwrap();
+        assert_eq!(partitions.len(), 2);
+        assert_eq!(partitions[0]["name"], "boot");
+        assert_eq!(partitions[1]["name"], "data");
+        assert_eq!(partitions[1]["size"], 2048);
+    }
+
+    #[test]
+    fn test_deep_merge_named_array_preserves_unmatched() {
+        let mut base = serde_json::json!({
+            "partitions": [
+                {"name": "boot", "size": 128, "size_unit": "mebibytes"},
+                {"name": "rootfs", "size": 160, "size_unit": "mebibytes"},
+                {"name": "var", "size": 512, "size_unit": "mebibytes"}
+            ]
+        });
+        let overlay = serde_json::json!({
+            "partitions": [
+                {"name": "var", "size": 1024}
+            ]
+        });
+        deep_merge_json(&mut base, overlay);
+
+        let partitions = base["partitions"].as_array().unwrap();
+        assert_eq!(partitions.len(), 3);
+        assert_eq!(partitions[0]["name"], "boot");
+        assert_eq!(partitions[0]["size"], 128);
+        assert_eq!(partitions[1]["name"], "rootfs");
+        assert_eq!(partitions[1]["size"], 160);
+        assert_eq!(partitions[2]["name"], "var");
+        assert_eq!(partitions[2]["size"], 1024);
+    }
+
+    #[test]
+    fn test_deep_merge_unnamed_array_replaces() {
+        let mut base = serde_json::json!({"files": ["a.txt", "b.txt", "c.txt"]});
+        let overlay = serde_json::json!({"files": ["x.txt"]});
+        deep_merge_json(&mut base, overlay);
+        assert_eq!(base["files"], serde_json::json!(["x.txt"]));
+    }
+
+    #[test]
+    fn test_deep_merge_empty_overlay() {
+        let mut base = serde_json::json!({"runtime": {"platform": "test"}});
+        let original = base.clone();
+        deep_merge_json(&mut base, serde_json::json!({}));
+        assert_eq!(base, original);
+    }
+
+    #[test]
+    fn test_deep_merge_multiple_overlays_ordered() {
+        let mut base = serde_json::json!({"runtime": {"platform": "original"}});
+        deep_merge_json(
+            &mut base,
+            serde_json::json!({"runtime": {"platform": "first"}}),
+        );
+        deep_merge_json(
+            &mut base,
+            serde_json::json!({"runtime": {"platform": "second"}}),
+        );
+        assert_eq!(base["runtime"]["platform"], "second");
+    }
+
+    #[test]
+    fn test_deep_merge_adds_top_level_section() {
+        let mut base = serde_json::json!({
+            "runtime": {"platform": "test", "architecture": "arm64"},
+            "storage_devices": {}
+        });
+        let overlay = serde_json::json!({
+            "provision": {
+                "profiles": {
+                    "img": {"script": "provision.sh"}
+                }
+            }
+        });
+        deep_merge_json(&mut base, overlay);
+        assert_eq!(base["provision"]["profiles"]["img"]["script"], "provision.sh");
+        assert_eq!(base["runtime"]["platform"], "test");
+    }
+
+    #[test]
+    fn test_from_file_with_overlays_integration() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let base_json = r#"{
+            "runtime": {"platform": "base-platform", "architecture": "arm64"},
+            "storage_devices": {
+                "rootdisk": {
+                    "out": "disk.img",
+                    "devpath": "/dev/mmcblk0",
+                    "images": {},
+                    "partitions": [
+                        {"name": "boot", "size": 128, "size_unit": "mebibytes"},
+                        {"name": "var", "size": 512, "size_unit": "mebibytes"}
+                    ]
+                }
+            }
+        }"#;
+        let overlay_json = r#"{
+            "runtime": {"platform": "overlay-platform"},
+            "storage_devices": {
+                "rootdisk": {
+                    "partitions": [
+                        {"name": "var", "size": 1024}
+                    ]
+                }
+            }
+        }"#;
+
+        let base_path = dir.path().join("base.json");
+        let overlay_path = dir.path().join("overlay.json");
+        std::fs::write(&base_path, base_json).unwrap();
+        std::fs::write(&overlay_path, overlay_json).unwrap();
+
+        let manifest =
+            Manifest::from_file_with_overlays(&base_path, &[overlay_path]).unwrap();
+
+        assert_eq!(manifest.runtime.platform, "overlay-platform");
+        assert_eq!(manifest.runtime.architecture, "arm64");
+
+        let rootdisk = manifest.storage_devices.get("rootdisk").unwrap();
+        assert_eq!(rootdisk.partitions.len(), 2);
+        assert_eq!(rootdisk.partitions[0].name, Some("boot".to_string()));
+        assert_eq!(rootdisk.partitions[0].size, 128);
+        assert_eq!(rootdisk.partitions[1].name, Some("var".to_string()));
+        assert_eq!(rootdisk.partitions[1].size, 1024);
+    }
+
+    #[test]
+    fn test_from_file_with_overlays_bad_json() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let base_path = dir.path().join("base.json");
+        let overlay_path = dir.path().join("bad.json");
+        std::fs::write(
+            &base_path,
+            r#"{"runtime":{"platform":"x","architecture":"y"},"storage_devices":{}}"#,
+        )
+        .unwrap();
+        std::fs::write(&overlay_path, "not valid json{{{").unwrap();
+
+        let err = Manifest::from_file_with_overlays(&base_path, &[overlay_path.clone()])
+            .unwrap_err();
+        assert!(err.contains("Failed to parse overlay JSON"));
+        assert!(err.contains("bad.json"));
+    }
+
+    #[test]
+    fn test_from_file_with_overlays_missing_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("base.json");
+        std::fs::write(
+            &base_path,
+            r#"{"runtime":{"platform":"x","architecture":"y"},"storage_devices":{}}"#,
+        )
+        .unwrap();
+
+        let overlay_path = dir.path().join("nonexistent.json");
+        let err = Manifest::from_file_with_overlays(&base_path, &[overlay_path]).unwrap_err();
+        assert!(err.contains("Failed to read overlay file"));
+    }
+
+    #[test]
+    fn test_load_and_merge_returns_json_string() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("base.json");
+        let overlay_path = dir.path().join("overlay.json");
+        std::fs::write(
+            &base_path,
+            r#"{"runtime":{"platform":"a","architecture":"arm64"},"storage_devices":{}}"#,
+        )
+        .unwrap();
+        std::fs::write(&overlay_path, r#"{"runtime":{"platform":"b"}}"#).unwrap();
+
+        let (manifest, merged_json) =
+            Manifest::load_and_merge(&base_path, &[overlay_path]).unwrap();
+        assert_eq!(manifest.runtime.platform, "b");
+        let json_str = merged_json.unwrap();
+        assert!(json_str.contains("\"platform\": \"b\""));
+    }
+
+    #[test]
+    fn test_load_and_merge_no_overlays_returns_none() {
+        let dir = tempfile::tempdir().unwrap();
+        let base_path = dir.path().join("base.json");
+        std::fs::write(
+            &base_path,
+            r#"{"runtime":{"platform":"a","architecture":"arm64"},"storage_devices":{}}"#,
+        )
+        .unwrap();
+
+        let (_, merged_json) = Manifest::load_and_merge(&base_path, &[]).unwrap();
+        assert!(merged_json.is_none());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -150,6 +150,10 @@ pub struct Runtime {
 pub struct Provision {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub envs: Option<HashMap<String, HashMap<String, String>>>,
+    /// Extra files to include alongside provision profile scripts (e.g., shared
+    /// helper libraries that scripts source at runtime).
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub files: Vec<String>,
     pub profiles: HashMap<String, ProvisionProfile>,
 }
 
@@ -900,6 +904,7 @@ mod tests {
 
         let provision = Provision {
             envs: None,
+            files: vec![],
             profiles: HashMap::new(),
         };
 
@@ -932,6 +937,7 @@ mod tests {
     fn test_provision_env_expansion_undefined_vars() {
         let provision = Provision {
             envs: None,
+            files: vec![],
             profiles: HashMap::new(),
         };
 
@@ -964,6 +970,7 @@ mod tests {
 
         let provision = Provision {
             envs: None,
+            files: vec![],
             profiles: HashMap::new(),
         };
 
@@ -994,6 +1001,7 @@ mod tests {
 
         let provision = Provision {
             envs: None,
+            files: vec![],
             profiles: HashMap::new(),
         };
 

--- a/tests/commands/stone/create/mod.rs
+++ b/tests/commands/stone/create/mod.rs
@@ -594,3 +594,89 @@ fn test_create_with_multiple_input_dirs_not_found() {
         .failure()
         .stdout(str::contains("not found in any input directory"));
 }
+
+#[test]
+fn test_create_with_overlay_writes_merged_manifest() {
+    use std::fs;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = temp_dir.path().join("input");
+    let output_path = temp_dir.path().join("output");
+    fs::create_dir_all(&input_path).unwrap();
+    fs::create_dir_all(&output_path).unwrap();
+
+    let manifest_content = r#"{
+        "runtime": {
+            "platform": "base-platform",
+            "architecture": "noarch"
+        },
+        "storage_devices": {
+            "rootdisk": {
+                "out": "disk.img",
+                "devpath": "/dev/mmcblk0",
+                "images": {
+                    "boot": "boot.img"
+                },
+                "partitions": [
+                    {"name": "boot", "size": 128, "size_unit": "mebibytes"},
+                    {"name": "var", "size": 512, "size_unit": "mebibytes"}
+                ]
+            }
+        }
+    }"#;
+
+    let overlay_content = r#"{
+        "runtime": {
+            "platform": "overlaid-platform"
+        },
+        "storage_devices": {
+            "rootdisk": {
+                "partitions": [
+                    {"name": "var", "size": 1024}
+                ]
+            }
+        }
+    }"#;
+
+    let manifest_path = input_path.join("manifest.json");
+    let overlay_path = input_path.join("overlay.json");
+    fs::write(&manifest_path, manifest_content).unwrap();
+    fs::write(&overlay_path, overlay_content).unwrap();
+    fs::write(input_path.join("boot.img"), "boot content").unwrap();
+    fs::write(input_path.join("os-release"), "NAME=Test\nVERSION_ID=1.0").unwrap();
+
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "create",
+            "--manifest-path",
+            &manifest_path.to_string_lossy(),
+            "--os-release",
+            &input_path.join("os-release").to_string_lossy(),
+            "--output-dir",
+            &output_path.to_string_lossy(),
+            "--input-dir",
+            &input_path.to_string_lossy(),
+            "--overlay",
+            &overlay_path.to_string_lossy(),
+        ])
+        .assert()
+        .success();
+
+    // The output manifest.json should contain the merged values
+    let output_manifest = fs::read_to_string(output_path.join("manifest.json")).unwrap();
+    assert!(
+        output_manifest.contains("overlaid-platform"),
+        "Output manifest should contain the overlaid platform"
+    );
+    // The var partition should have the merged size
+    assert!(
+        output_manifest.contains("1024"),
+        "Output manifest should contain the overlaid var partition size"
+    );
+    // The boot partition should still be present from the base
+    assert!(
+        output_manifest.contains("\"boot\""),
+        "Output manifest should still contain the boot partition"
+    );
+}

--- a/tests/commands/stone/describe_manifest/mod.rs
+++ b/tests/commands/stone/describe_manifest/mod.rs
@@ -1,4 +1,5 @@
 use assert_cmd::Command;
+use predicates::str::contains;
 
 #[test]
 fn test_describe_manifest() {
@@ -11,4 +12,34 @@ fn test_describe_manifest() {
         ])
         .assert()
         .success();
+}
+
+#[test]
+fn test_describe_manifest_with_overlay() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+
+    // Overlay changes the platform name
+    let overlay_content = r#"{
+        "runtime": {
+            "platform": "avocado-overlay-test"
+        }
+    }"#;
+    let overlay_path = temp_dir.path().join("overlay.json");
+    fs::write(&overlay_path, overlay_content).unwrap();
+
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "describe-manifest",
+            "--manifest-path",
+            "tests/fixtures/coverage/stone.json",
+            "--overlay",
+            &overlay_path.to_string_lossy(),
+        ])
+        .assert()
+        .success()
+        .stdout(contains("avocado-overlay-test"));
 }

--- a/tests/commands/stone/validate/mod.rs
+++ b/tests/commands/stone/validate/mod.rs
@@ -635,3 +635,184 @@ fn test_validate_with_multiple_input_dirs_not_found() {
         .failure()
         .stdout(contains("test.img"));
 }
+
+// --- Overlay tests ---
+
+#[test]
+fn test_validate_with_overlay() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = temp_dir.path();
+
+    let manifest_content = r#"{
+        "runtime": {
+            "platform": "test-platform",
+            "architecture": "noarch"
+        },
+        "storage_devices": {
+            "rootdisk": {
+                "out": "disk.img",
+                "devpath": "/dev/mmcblk0",
+                "images": {
+                    "boot": "boot.img"
+                },
+                "partitions": [
+                    {"name": "boot", "size": 128, "size_unit": "mebibytes"},
+                    {"name": "var", "size": 512, "size_unit": "mebibytes"}
+                ]
+            }
+        }
+    }"#;
+
+    // Overlay changes the image reference to a different file
+    let overlay_content = r#"{
+        "storage_devices": {
+            "rootdisk": {
+                "images": {
+                    "boot": "custom-boot.img"
+                }
+            }
+        }
+    }"#;
+
+    let manifest_path = input_path.join("manifest.json");
+    let overlay_path = input_path.join("overlay.json");
+    fs::write(&manifest_path, manifest_content).unwrap();
+    fs::write(&overlay_path, overlay_content).unwrap();
+    // Create the file the overlay references
+    fs::write(input_path.join("custom-boot.img"), "custom boot").unwrap();
+
+    // Should succeed — the overlay changed the image ref to one that exists
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "validate",
+            "--manifest-path",
+            &manifest_path.to_string_lossy(),
+            "--input-dir",
+            &input_path.to_string_lossy(),
+            "--overlay",
+            &overlay_path.to_string_lossy(),
+        ])
+        .assert()
+        .success();
+}
+
+#[test]
+fn test_validate_overlay_file_not_found() {
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "validate",
+            "--manifest-path",
+            "tests/fixtures/coverage/stone.json",
+            "--input-dir",
+            "tests/fixtures/coverage",
+            "--overlay",
+            "/tmp/nonexistent_overlay_12345.json",
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("Failed to read overlay file"));
+}
+
+#[test]
+fn test_validate_overlay_invalid_json() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let bad_overlay = temp_dir.path().join("bad.json");
+    fs::write(&bad_overlay, "not valid json{{{").unwrap();
+
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "validate",
+            "--manifest-path",
+            "tests/fixtures/coverage/stone.json",
+            "--input-dir",
+            "tests/fixtures/coverage",
+            "--overlay",
+            &bad_overlay.to_string_lossy(),
+        ])
+        .assert()
+        .failure()
+        .stdout(contains("Failed to parse overlay JSON"));
+}
+
+#[test]
+fn test_validate_with_multiple_overlays_order() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let temp_dir = TempDir::new().unwrap();
+    let input_path = temp_dir.path();
+
+    let manifest_content = r#"{
+        "runtime": {
+            "platform": "test-platform",
+            "architecture": "noarch"
+        },
+        "storage_devices": {
+            "rootdisk": {
+                "out": "disk.img",
+                "devpath": "/dev/mmcblk0",
+                "images": {
+                    "boot": "first.img"
+                },
+                "partitions": []
+            }
+        }
+    }"#;
+
+    // First overlay changes image ref
+    let overlay1 = r#"{
+        "storage_devices": {
+            "rootdisk": {
+                "images": {
+                    "boot": "second.img"
+                }
+            }
+        }
+    }"#;
+
+    // Second overlay overrides it again — last wins
+    let overlay2 = r#"{
+        "storage_devices": {
+            "rootdisk": {
+                "images": {
+                    "boot": "final.img"
+                }
+            }
+        }
+    }"#;
+
+    let manifest_path = input_path.join("manifest.json");
+    let overlay1_path = input_path.join("overlay1.json");
+    let overlay2_path = input_path.join("overlay2.json");
+    fs::write(&manifest_path, manifest_content).unwrap();
+    fs::write(&overlay1_path, overlay1).unwrap();
+    fs::write(&overlay2_path, overlay2).unwrap();
+    // Only create the file the final overlay references
+    fs::write(input_path.join("final.img"), "final image").unwrap();
+
+    // Should succeed — after both overlays, boot points to final.img which exists
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "validate",
+            "--manifest-path",
+            &manifest_path.to_string_lossy(),
+            "--input-dir",
+            &input_path.to_string_lossy(),
+            "--overlay",
+            &overlay1_path.to_string_lossy(),
+            "--overlay",
+            &overlay2_path.to_string_lossy(),
+        ])
+        .assert()
+        .success();
+}


### PR DESCRIPTION
## Summary

- Patch release adding `provision.files` to the manifest schema for extra helper scripts copied alongside provision profile scripts (cherry-pick of e0182e9 from `jschneck/rpi-tryboot`).
- Pre-existing rustfmt + clippy drift fixed so CI's check steps pass.
- Cargo bump 2.1.0 → 2.1.1.

`provision.files` lets BSPs whose provision scripts source shared bash helpers — `build-disk-image.sh` on stm32mp25-dk / rzv2n-sr-som / orangepi-5-plus, `stone-{device,tryboot,mbr,rpiboot}-common.sh` on RPi — declare those helpers so `stone create` and `stone bundle` copy them into the runtime stone dir alongside the named profile script. Without this, the helpers landed in `DEPLOY_DIR_IMAGE` but never reached the runtime dir, and provisioning failed with `${SCRIPT_DIR}/build-disk-image.sh: No such file or directory`.

## Branch shape

```
7c46ad4 chore: bump version to 2.1.1
2bdd20b style: rustfmt + clippy cleanup
e846212 feat: add provision.files for extra scripts alongside profile scripts
495f3fa feat: add --overlay flag for manifest config overlays  ← already on main
a46f79d chore: bump version to 2.1.0                            ← rel/2.1.0 base
```

The middle commit is the cherry-pick. The `style:` commit is decoupled — it cleans up rustfmt + clippy drift introduced by the `--overlay` work that snuck past CI somewhere. Worth backporting to `main` independently of this release.

## Test plan
- [x] `cargo check --locked`
- [x] `cargo fmt --check`
- [x] `cargo build --locked`
- [x] `cargo test --locked` (138 tests, all green)
- [x] `cargo clippy --all-targets --all-features --locked -- -D warnings`
- [ ] Bump `meta-avocado-distro/recipes-devtools/stone/stone_2.1.0.bb` → `stone_2.1.1.bb` in avocado-os and rebuild SDK; confirm `build-disk-image.sh` lands in the runtime stone dir for stm32mp25-dk / rzv2n-sr-som / orangepi-5-plus and `avocado provision` succeeds.