### PR TITLE
Support additive FAT files via files_append

### DIFF
--- a/src/commands/stone/bundle.rs
+++ b/src/commands/stone/bundle.rs
@@ -1,7 +1,8 @@
 use crate::fat;
 use crate::log::*;
 use crate::manifest::{
-    BuildArgs, FatVariant, FileEntry, Image, Manifest, resolve_partition_size_bytes, to_bytes,
+    BuildArgs, FatVariant, FileEntry, Image, Manifest, merge_fat_files,
+    resolve_partition_size_bytes, to_bytes,
 };
 use clap::Args;
 use sha2::{Digest, Sha256};
@@ -85,23 +86,22 @@ impl BundleArgs {
 }
 
 /// Parse `NAME=BYTES` strings (as accepted by `--partition-size`) into a map.
-pub fn parse_partition_size_overrides(
-    raw: &[String],
-) -> Result<HashMap<String, u64>, String> {
+pub fn parse_partition_size_overrides(raw: &[String]) -> Result<HashMap<String, u64>, String> {
     let mut map = HashMap::new();
     for spec in raw {
-        let (name, value) = spec.split_once('=').ok_or_else(|| {
-            format!("--partition-size expects NAME=BYTES, got '{spec}'")
-        })?;
+        let (name, value) = spec
+            .split_once('=')
+            .ok_or_else(|| format!("--partition-size expects NAME=BYTES, got '{spec}'"))?;
         let name = name.trim();
         if name.is_empty() {
             return Err(format!(
                 "--partition-size has empty partition name in '{spec}'"
             ));
         }
-        let bytes: u64 = value.trim().parse().map_err(|e| {
-            format!("--partition-size '{spec}' has non-integer byte value: {e}")
-        })?;
+        let bytes: u64 = value
+            .trim()
+            .parse()
+            .map_err(|e| format!("--partition-size '{spec}' has non-integer byte value: {e}"))?;
         map.insert(name.to_string(), bytes);
     }
     Ok(map)
@@ -373,7 +373,12 @@ fn build_all_images(
             match image {
                 Image::Object {
                     out,
-                    build_args: Some(BuildArgs::Fat { variant, files }),
+                    build_args:
+                        Some(BuildArgs::Fat {
+                            variant,
+                            files,
+                            files_append,
+                        }),
                     size,
                     size_unit,
                     ..
@@ -387,7 +392,9 @@ fn build_all_images(
                         FatVariant::Fat32 => fat::FatType::Fat32,
                     };
 
-                    let fat_manifest = create_fat_manifest_with_resolved_paths(files, input_dirs)?;
+                    let merged_files = merge_fat_files(files, files_append)?;
+                    let fat_manifest =
+                        create_fat_manifest_with_resolved_paths(&merged_files, input_dirs)?;
                     let temp_manifest_path =
                         build_dir.join(format!("temp_manifest_{image_name}.json"));
                     let manifest_json = serde_json::to_string_pretty(&fat_manifest)
@@ -695,7 +702,8 @@ fn generate_bundle_json(
     for device in manifest.storage_devices.values() {
         if !device.partitions.is_empty() {
             let mut cursor_bytes: u64 = 0;
-            let mut partitions: Vec<serde_json::Value> = Vec::with_capacity(device.partitions.len());
+            let mut partitions: Vec<serde_json::Value> =
+                Vec::with_capacity(device.partitions.len());
             for p in &device.partitions {
                 let (size_bytes, _size_unit_hint) =
                     resolve_partition_size_bytes(p, partition_size_overrides)?;

--- a/src/commands/stone/bundle.rs
+++ b/src/commands/stone/bundle.rs
@@ -323,8 +323,12 @@ fn copy_manifest_inputs(
             {
                 copy_file(&src, &build_dir.join(template), verbose)?;
             }
-            // Copy FAT source files (e.g., initramfs, bzImage) so provision can rebuild FAT images
-            for file_entry in image.files() {
+            // Copy FAT source files (e.g., initramfs, bzImage) so provision can
+            // rebuild FAT images. all_files() rather than files(): an appended
+            // entry names a source that provision needs staged just as much as a
+            // base one, and skipping it produced a bundle that referenced a file
+            // it had not copied.
+            for file_entry in &image.all_files()? {
                 let input_filename = file_entry.input_filename();
                 if let Some(src) = find_file_in_dirs(input_filename, input_dirs) {
                     let dest = build_dir.join(input_filename);

--- a/src/commands/stone/create.rs
+++ b/src/commands/stone/create.rs
@@ -281,10 +281,12 @@ fn process_image(
         }
     }
 
-    // If the image has files defined, copy those individual files
-    let files = image.files();
+    // If the image has files defined, copy those individual files.
+    // all_files() so an appended entry is copied rather than silently omitted -
+    // create printed "Created." either way, unlike a missing base input.
+    let files = image.all_files()?;
     if !files.is_empty() {
-        for file_entry in files {
+        for file_entry in &files {
             if let Err(e) = process_file_entry(file_entry, input_dirs, output_dir, verbose) {
                 return Err(format!(
                     "Failed to process file in image '{image_name}': {e}"

--- a/src/commands/stone/describe_manifest.rs
+++ b/src/commands/stone/describe_manifest.rs
@@ -167,19 +167,16 @@ fn describe_manifest(manifest: &Manifest) -> Result<(), String> {
                 }
             }
 
-            // Show files from build_args for fat builds, otherwise from image
-            let files = if let Some(build_args) = image.build_args() {
-                match build_args {
-                    crate::manifest::BuildArgs::Fat { files, .. } => files.as_slice(),
-                    _ => image.files(),
-                }
-            } else {
-                image.files()
-            };
+            // Base files plus appended ones. A misplaced or misspelled
+            // files_append key is silently ignored, so this listing is the
+            // operator's only confirmation an append landed - and it used to
+            // print a count that included appended entries above a list that
+            // named none of them.
+            let files = image.all_files()?;
 
             if !files.is_empty() {
                 output.push_str(&format!("    Files ({}):\n", files.len()));
-                for file_entry in files {
+                for file_entry in &files {
                     match file_entry {
                         crate::manifest::FileEntry::String(filename) => {
                             output.push_str(&format!("      {filename}\n"));

--- a/src/commands/stone/describe_manifest.rs
+++ b/src/commands/stone/describe_manifest.rs
@@ -144,10 +144,20 @@ fn describe_manifest(manifest: &Manifest) -> Result<(), String> {
                     output.push_str("    Build Args:\n");
                     output.push_str(&format!("      type: {}\n", build_args.build_type()));
                     match build_args {
-                        crate::manifest::BuildArgs::Fat { variant, files } => {
+                        crate::manifest::BuildArgs::Fat {
+                            variant,
+                            files,
+                            files_append,
+                        } => {
                             output.push_str(&format!("      variant: {variant:?}\n"));
                             if !files.is_empty() {
                                 output.push_str(&format!("      files: {} file(s)\n", files.len()));
+                            }
+                            if !files_append.is_empty() {
+                                output.push_str(&format!(
+                                    "      files_append: {} file(s)\n",
+                                    files_append.len()
+                                ));
                             }
                         }
                         crate::manifest::BuildArgs::Fwup { template } => {
@@ -221,10 +231,18 @@ fn describe_manifest(manifest: &Manifest) -> Result<(), String> {
             output.push_str("\nStorage Device Build Args:\n");
             output.push_str(&format!("  type: {}\n", build_args.build_type()));
             match build_args {
-                crate::manifest::BuildArgs::Fat { variant, files } => {
+                crate::manifest::BuildArgs::Fat {
+                    variant,
+                    files,
+                    files_append,
+                } => {
                     output.push_str(&format!("  variant: {variant:?}\n"));
                     if !files.is_empty() {
                         output.push_str(&format!("  files: {} file(s)\n", files.len()));
+                    }
+                    if !files_append.is_empty() {
+                        output
+                            .push_str(&format!("  files_append: {} file(s)\n", files_append.len()));
                     }
                 }
                 crate::manifest::BuildArgs::Fwup { template } => {

--- a/src/commands/stone/provision.rs
+++ b/src/commands/stone/provision.rs
@@ -603,9 +603,9 @@ fn calculate_avocado_env_vars(
             current_offset
         };
 
-        let partition_size = if partition.size.is_some() {
+        let partition_size = if let Some(size) = partition.size {
             convert_to_blocks(
-                partition.size.unwrap(),
+                size,
                 partition.size_unit.as_deref().unwrap(),
                 block_size,
             )?

--- a/src/commands/stone/provision.rs
+++ b/src/commands/stone/provision.rs
@@ -2,7 +2,8 @@ use crate::commands::stone::bundle::parse_partition_size_overrides;
 use crate::fat;
 use crate::log::*;
 use crate::manifest::{
-    BuildArgs, FatVariant, FileEntry, Image, Manifest, resolve_partition_size_bytes,
+    BuildArgs, FatVariant, FileEntry, Image, Manifest, merge_fat_files,
+    resolve_partition_size_bytes,
 };
 use clap::Args;
 
@@ -204,17 +205,24 @@ fn build_image(
             size_unit,
             ..
         } => match build_args {
-            BuildArgs::Fat { variant, files } => build_fat_image(FatImageParams {
-                image_name,
-                out,
+            BuildArgs::Fat {
                 variant,
                 files,
-                size,
-                size_unit,
-                input_dirs,
-                build_dir,
-                verbose,
-            }),
+                files_append,
+            } => {
+                let merged_files = merge_fat_files(files, files_append)?;
+                build_fat_image(FatImageParams {
+                    image_name,
+                    out,
+                    variant,
+                    files: &merged_files,
+                    size,
+                    size_unit,
+                    input_dirs,
+                    build_dir,
+                    verbose,
+                })
+            }
             BuildArgs::Fwup { template } => {
                 build_fwup_image(image_name, image, template, input_dirs, build_dir, verbose)
             }
@@ -604,14 +612,9 @@ fn calculate_avocado_env_vars(
         };
 
         let partition_size = if let Some(size) = partition.size {
-            convert_to_blocks(
-                size,
-                partition.size_unit.as_deref().unwrap(),
-                block_size,
-            )?
+            convert_to_blocks(size, partition.size_unit.as_deref().unwrap(), block_size)?
         } else {
-            let (bytes, _) =
-                resolve_partition_size_bytes(partition, partition_size_overrides)?;
+            let (bytes, _) = resolve_partition_size_bytes(partition, partition_size_overrides)?;
             bytes / (block_size as u64)
         };
 

--- a/src/commands/stone/validate.rs
+++ b/src/commands/stone/validate.rs
@@ -175,17 +175,17 @@ pub fn validate_command(
                 }
             }
 
-            // Process files from build_args for fat builds, otherwise from image
-            let files = if let Some(build_args) = image.build_args() {
-                match build_args {
-                    crate::manifest::BuildArgs::Fat { files, .. } => files.as_slice(),
-                    _ => image.files(),
-                }
-            } else {
-                image.files()
-            };
+            // The merged list, so validate checks appended sources exist and
+            // runs the collision guard. Validating only base `files` let a
+            // manifest print "Validated." and then hard-fail at bundle time,
+            // which is the one outcome a pre-build check must not produce.
+            // A collision aborts rather than joining the missing-file tally:
+            // those are "this input is absent", which the report below counts
+            // and lists, while this is "these two entries cannot both exist".
+            // Folding it into that count would misreport it as a missing file.
+            let files = image.all_files()?;
 
-            for file_entry in files {
+            for file_entry in &files {
                 if find_file_in_dirs(file_entry.input_filename(), input_dirs).is_none() {
                     missing_files.push((
                         device_name.clone(),

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -20,6 +20,11 @@ pub enum BuildArgs {
         variant: FatVariant,
         #[serde(default, skip_serializing_if = "Vec::is_empty")]
         files: Vec<FileEntry>,
+        /// Additional FAT files merged onto `files` at bundle time, deduplicated
+        /// by output path. Lets a delivery hook append a custom entry (e.g. a
+        /// device-tree overlay) without restating the base `files` list.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        files_append: Vec<FileEntry>,
     },
     #[serde(rename = "fwup")]
     Fwup {
@@ -46,6 +51,14 @@ impl BuildArgs {
     pub fn fat_files(&self) -> &[FileEntry] {
         match self {
             BuildArgs::Fat { files, .. } => files,
+            _ => &[],
+        }
+    }
+
+    #[allow(dead_code)]
+    pub fn fat_files_append(&self) -> &[FileEntry] {
+        match self {
+            BuildArgs::Fat { files_append, .. } => files_append,
             _ => &[],
         }
     }
@@ -270,7 +283,7 @@ impl Image {
     }
 }
 
-#[derive(Debug, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(untagged)]
 pub enum FileEntry {
     String(String),
@@ -287,6 +300,16 @@ impl FileEntry {
         match self {
             FileEntry::String(filename) => filename,
             FileEntry::Object { input, .. } => input,
+        }
+    }
+
+    /// Output path this entry produces on the target filesystem. A bare
+    /// `String` entry outputs under its own name; an `Object` outputs under
+    /// its explicit `out`.
+    pub fn output_name(&self) -> &str {
+        match self {
+            FileEntry::String(filename) => filename,
+            FileEntry::Object { output, .. } => output,
         }
     }
 }
@@ -375,14 +398,11 @@ pub fn resolve_partition_size_bytes(
             .ok_or_else(|| "partition has size but no size_unit".to_string())?;
         return Ok((to_bytes(size as u64, Some(unit)), unit.to_string()));
     }
-    let name = p
-        .name
-        .as_deref()
-        .ok_or_else(|| "partition omits size but has no name to match against overrides".to_string())?;
+    let name = p.name.as_deref().ok_or_else(|| {
+        "partition omits size but has no name to match against overrides".to_string()
+    })?;
     let raw = overrides.get(name).copied().ok_or_else(|| {
-        format!(
-            "partition '{name}' omits size; no --partition-size override was supplied"
-        )
+        format!("partition '{name}' omits size; no --partition-size override was supplied")
     })?;
     let aligned = align_up(raw, partition_alignment_bytes(p));
     Ok((aligned, "bytes".to_string()))
@@ -423,10 +443,7 @@ impl Manifest {
         for (dev_name, device) in &self.storage_devices {
             let last_idx = device.partitions.len().saturating_sub(1);
             for (idx, p) in device.partitions.iter().enumerate() {
-                let label = p
-                    .name
-                    .clone()
-                    .unwrap_or_else(|| format!("#{idx}"));
+                let label = p.name.clone().unwrap_or_else(|| format!("#{idx}"));
                 match (p.size.is_some(), p.size_unit.is_some()) {
                     (true, false) => {
                         return Err(format!(
@@ -691,6 +708,37 @@ pub fn deep_merge_json(base: &mut Value, overlay: Value) {
     }
 }
 
+/// Merge a base FAT `files` list with an additive `files_append` list, keyed by
+/// output path. An entry whose `{in,out}` is identical to one already present
+/// collapses to a single entry, so a regenerative delivery hook that re-emits
+/// the same entry on every rebuild is an idempotent no-op. Two entries that
+/// share an output path but resolve from different inputs are a hard error: a
+/// silent overwrite of a boot file (e.g. `overlays/foo.dtbo`) could brick the
+/// device, so the conflict must surface at build time.
+pub fn merge_fat_files(base: &[FileEntry], append: &[FileEntry]) -> Result<Vec<FileEntry>, String> {
+    let mut merged: Vec<FileEntry> = Vec::new();
+    for entry in base.iter().chain(append.iter()) {
+        if let Some(existing) = merged
+            .iter()
+            .find(|e| e.output_name() == entry.output_name())
+        {
+            if existing.input_filename() != entry.input_filename() {
+                return Err(format!(
+                    "[ERROR] Conflicting FAT file entries for output '{}': inputs '{}' and '{}' differ. \
+A custom overlay must not overwrite an existing boot file; give it a distinct output name.",
+                    entry.output_name(),
+                    existing.input_filename(),
+                    entry.input_filename(),
+                ));
+            }
+            // Identical {in,out}: idempotent, already present.
+            continue;
+        }
+        merged.push(entry.clone());
+    }
+    Ok(merged)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -700,6 +748,7 @@ mod tests {
         let fat_args = BuildArgs::Fat {
             variant: FatVariant::Fat32,
             files: vec![],
+            files_append: vec![],
         };
 
         let serialized = serde_json::to_value(&fat_args).unwrap();
@@ -725,6 +774,7 @@ mod tests {
         let fat_args = BuildArgs::Fat {
             variant: FatVariant::Fat16,
             files: vec![],
+            files_append: vec![],
         };
         assert_eq!(fat_args.build_type(), "fat");
 
@@ -741,6 +791,7 @@ mod tests {
             build_args: Some(BuildArgs::Fat {
                 variant: FatVariant::Fat32,
                 files: vec![],
+                files_append: vec![],
             }),
             size: 100,
             size_unit: "megabytes".to_string(),
@@ -827,6 +878,7 @@ mod tests {
                     output: "dest.bin".to_string(),
                 },
             ],
+            files_append: vec![],
         };
 
         assert_eq!(fat_args.build_type(), "fat");
@@ -1471,7 +1523,12 @@ mod tests {
         assert!(merged_json.is_none());
     }
 
-    fn partition_with_size(size: Option<i64>, size_unit: Option<&str>, expand: Option<&str>, name: Option<&str>) -> Partition {
+    fn partition_with_size(
+        size: Option<i64>,
+        size_unit: Option<&str>,
+        expand: Option<&str>,
+        name: Option<&str>,
+    ) -> Partition {
         Partition {
             name: name.map(String::from),
             image: None,
@@ -1594,7 +1651,10 @@ mod tests {
         let p = partition_with_size(None, None, Some("true"), Some("var"));
         let overrides = HashMap::new();
         let err = resolve_partition_size_bytes(&p, &overrides).unwrap_err();
-        assert!(err.contains("var"), "error should name the partition: {err}");
+        assert!(
+            err.contains("var"),
+            "error should name the partition: {err}"
+        );
         assert!(err.contains("--partition-size"));
     }
 
@@ -1613,7 +1673,11 @@ mod tests {
             partition_with_size(Some(256), Some("mebibytes"), None, Some("boot")),
             partition_with_size(None, None, Some("true"), Some("var")),
         ]);
-        assert!(m.validate_partitions().is_ok(), "{:?}", m.validate_partitions());
+        assert!(
+            m.validate_partitions().is_ok(),
+            "{:?}",
+            m.validate_partitions()
+        );
     }
 
     #[test]
@@ -1705,10 +1769,98 @@ mod tests {
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("m.json");
         std::fs::write(&path, json).unwrap();
-        let m = Manifest::from_file(&path).expect("from_file should accept omitted size with expand=true on last partition");
+        let m = Manifest::from_file(&path)
+            .expect("from_file should accept omitted size with expand=true on last partition");
         let parts = &m.storage_devices["main"].partitions;
         assert_eq!(parts.len(), 2);
         assert!(parts[1].size.is_none());
         assert!(parts[1].size_unit.is_none());
+    }
+
+    // --- merge_fat_files (files_append) tests ---
+
+    fn fe_obj(input: &str, output: &str) -> FileEntry {
+        FileEntry::Object {
+            input: input.to_string(),
+            output: output.to_string(),
+        }
+    }
+
+    #[test]
+    fn test_file_entry_output_name_string_and_object() {
+        // A bare String entry outputs under its own name (in == out).
+        assert_eq!(
+            FileEntry::String("a.dtbo".to_string()).output_name(),
+            "a.dtbo"
+        );
+        // An Object entry outputs under its explicit `out`.
+        assert_eq!(
+            fe_obj("a.dtbo", "overlays/a.dtbo").output_name(),
+            "overlays/a.dtbo"
+        );
+    }
+
+    #[test]
+    fn test_merge_fat_files_appends_new_entry() {
+        let base = vec![fe_obj("config.txt", "config.txt")];
+        let append = vec![fe_obj("bbproto.dtbo", "overlays/bbproto.dtbo")];
+        let merged = merge_fat_files(&base, &append).unwrap();
+        assert_eq!(merged.len(), 2);
+        assert_eq!(merged[0].output_name(), "config.txt");
+        assert_eq!(merged[1].output_name(), "overlays/bbproto.dtbo");
+    }
+
+    #[test]
+    fn test_merge_fat_files_identical_entry_collapses() {
+        // A regenerative hook re-emits the same {in,out} on every rebuild; that
+        // must be an idempotent no-op, not a hard error (Fable C2).
+        let base = vec![fe_obj("bbproto.dtbo", "overlays/bbproto.dtbo")];
+        let append = vec![fe_obj("bbproto.dtbo", "overlays/bbproto.dtbo")];
+        let merged = merge_fat_files(&base, &append).unwrap();
+        assert_eq!(merged.len(), 1);
+        assert_eq!(merged[0].output_name(), "overlays/bbproto.dtbo");
+    }
+
+    #[test]
+    fn test_merge_fat_files_same_out_different_in_errors() {
+        // Same output path, different source = a real conflict (would silently
+        // overwrite a boot-critical file). Hard error (Fable C2 / Risk #5).
+        let base = vec![fe_obj("vc4-kms-v3d-pi5.dtbo", "overlays/foo.dtbo")];
+        let append = vec![fe_obj("user.dtbo", "overlays/foo.dtbo")];
+        let err = merge_fat_files(&base, &append).unwrap_err();
+        assert!(
+            err.contains("overlays/foo.dtbo"),
+            "error should name the colliding out: {err}"
+        );
+    }
+
+    #[test]
+    fn test_merge_fat_files_string_object_same_out_collapses() {
+        // String("f") and Object{in:"f", out:"f"} describe the same delivery.
+        let base = vec![FileEntry::String("f".to_string())];
+        let append = vec![fe_obj("f", "f")];
+        let merged = merge_fat_files(&base, &append).unwrap();
+        assert_eq!(merged.len(), 1);
+    }
+
+    #[test]
+    fn test_fat_build_args_parses_files_append() {
+        let json = r#"{"type":"fat","variant":"FAT32","files":[{"in":"config.txt","out":"config.txt"}],"files_append":[{"in":"bbproto.dtbo","out":"overlays/bbproto.dtbo"}]}"#;
+        let args: BuildArgs = serde_json::from_str(json).unwrap();
+        assert_eq!(args.fat_files().len(), 1);
+        assert_eq!(args.fat_files_append().len(), 1);
+        assert_eq!(
+            args.fat_files_append()[0].output_name(),
+            "overlays/bbproto.dtbo"
+        );
+    }
+
+    #[test]
+    fn test_fat_build_args_files_append_defaults_empty() {
+        // A manifest without files_append still parses (backward compatible).
+        let json =
+            r#"{"type":"fat","variant":"FAT32","files":[{"in":"config.txt","out":"config.txt"}]}"#;
+        let args: BuildArgs = serde_json::from_str(json).unwrap();
+        assert!(args.fat_files_append().is_empty());
     }
 }

--- a/src/manifest.rs
+++ b/src/manifest.rs
@@ -254,6 +254,26 @@ impl Image {
         }
     }
 
+    /// Every FAT file this image contributes: base `files` with `files_append`
+    /// merged in, deduplicated by output path.
+    ///
+    /// [`Image::files`] returns only the base list, which is what left the
+    /// feature half-wired: each consumer that stages source files copied base
+    /// inputs and skipped appended ones, so `bundle` produced an `.aos` naming
+    /// a file it had not staged and `provision` failed a command later. Anything
+    /// that needs the files this image will actually contain wants this, not
+    /// `files()`.
+    ///
+    /// Returns the conflict error from [`merge_fat_files`] rather than
+    /// swallowing it, so a colliding append fails at the caller instead of
+    /// silently losing one of the two entries.
+    pub fn all_files(&self) -> Result<Vec<FileEntry>, String> {
+        match self.build_args() {
+            Some(args) => merge_fat_files(args.fat_files(), args.fat_files_append()),
+            None => Ok(self.files().to_vec()),
+        }
+    }
+
     pub fn size(&self) -> Option<i64> {
         match self {
             Image::String(_) => None,
@@ -671,12 +691,39 @@ impl Provision {
 /// win on conflict). Arrays of named objects (elements with a `"name"` string
 /// field) are merged by matching names. All other values (scalars, unnamed
 /// arrays) in `overlay` replace `base` entirely.
+/// Concatenate `overlay` onto `base` when both are arrays, rather than
+/// replacing. Falls back to replacement for any other shape, matching
+/// [`deep_merge_json`]'s behaviour on a type mismatch.
+fn concat_json_array(base: &mut Value, overlay: Value) {
+    match (base, overlay) {
+        (Value::Array(base_arr), Value::Array(overlay_arr)) => base_arr.extend(overlay_arr),
+        (base, overlay) => *base = overlay,
+    }
+}
+
 pub fn deep_merge_json(base: &mut Value, overlay: Value) {
     match (base, overlay) {
         (Value::Object(base_map), Value::Object(overlay_map)) => {
             for (key, overlay_val) in overlay_map {
+                let is_append_list = key == "files_append";
                 let entry = base_map.entry(key).or_insert(Value::Null);
-                deep_merge_json(entry, overlay_val);
+                if is_append_list {
+                    // `files_append` is additive by definition - its purpose is
+                    // letting independent delivery hooks each contribute an
+                    // entry without restating the others. The generic array rule
+                    // below replaces the list unless every element carries a
+                    // "name", and FileEntry is {in,out}, so routing this through
+                    // it made the second overlay silently drop the first: the
+                    // key inherited the exact clobbering it exists to avoid.
+                    //
+                    // Concatenating rather than deduplicating here on purpose.
+                    // merge_fat_files owns that policy, and it distinguishes an
+                    // idempotent re-emit from a real collision; doing it twice,
+                    // in two places, is how the two would drift.
+                    concat_json_array(entry, overlay_val);
+                } else {
+                    deep_merge_json(entry, overlay_val);
+                }
             }
         }
         (Value::Array(base_arr), Value::Array(overlay_arr)) => {
@@ -715,16 +762,26 @@ pub fn deep_merge_json(base: &mut Value, overlay: Value) {
 /// share an output path but resolve from different inputs are a hard error: a
 /// silent overwrite of a boot file (e.g. `overlays/foo.dtbo`) could brick the
 /// device, so the conflict must surface at build time.
+///
+/// Only appended entries are checked. Base `files` are carried through
+/// unexamined even when two of them share an output: such a manifest built
+/// before this feature existed (fatfs is last-write-wins) and turning it into a
+/// build failure here would be an unannounced break of manifests nobody
+/// touched. The dedup is a property of appending, which is what the doc above
+/// describes and what a delivery hook can actually trip.
+///
+/// Comparison is on [`fat_output_key`], not the raw string - see there for why
+/// exact equality was not enough.
 pub fn merge_fat_files(base: &[FileEntry], append: &[FileEntry]) -> Result<Vec<FileEntry>, String> {
-    let mut merged: Vec<FileEntry> = Vec::new();
-    for entry in base.iter().chain(append.iter()) {
+    let mut merged: Vec<FileEntry> = base.to_vec();
+    for entry in append {
         if let Some(existing) = merged
             .iter()
-            .find(|e| e.output_name() == entry.output_name())
+            .find(|e| fat_output_key(e.output_name()) == fat_output_key(entry.output_name()))
         {
             if existing.input_filename() != entry.input_filename() {
                 return Err(format!(
-                    "[ERROR] Conflicting FAT file entries for output '{}': inputs '{}' and '{}' differ. \
+                    "Conflicting FAT file entries for output '{}': inputs '{}' and '{}' differ. \
 A custom overlay must not overwrite an existing boot file; give it a distinct output name.",
                     entry.output_name(),
                     existing.input_filename(),
@@ -737,6 +794,28 @@ A custom overlay must not overwrite an existing boot file; give it a distinct ou
         merged.push(entry.clone());
     }
     Ok(merged)
+}
+
+/// Normalize a FAT output path to the identity the filesystem will actually
+/// resolve it by.
+///
+/// Comparing output paths verbatim let a variant duplicate through the guard
+/// and into the image, where fatfs collapses it anyway: `eq_name` uppercases
+/// both sides, `find_entry` compares ignoring case, and `create_file` returns
+/// the existing entry *without truncating*. So `overlays/VC4.DTBO` written over
+/// `overlays/vc4.dtbo` produced one directory entry holding the overlay's bytes
+/// followed by whatever of the original ran past them - the brick this guard
+/// exists to prevent, reached through a spelling it did not check.
+///
+/// Uppercasing covers the case half. Dropping empty segments covers the path
+/// form half, so `./x`, `x` and `a//b` do not read as three distinct outputs.
+fn fat_output_key(output: &str) -> String {
+    output
+        .split('/')
+        .filter(|segment| !segment.is_empty() && *segment != ".")
+        .map(|segment| segment.to_uppercase())
+        .collect::<Vec<_>>()
+        .join("/")
 }
 
 #[cfg(test)]
@@ -1862,5 +1941,106 @@ mod tests {
             r#"{"type":"fat","variant":"FAT32","files":[{"in":"config.txt","out":"config.txt"}]}"#;
         let args: BuildArgs = serde_json::from_str(json).unwrap();
         assert!(args.fat_files_append().is_empty());
+    }
+
+    #[test]
+    fn two_overlays_each_appending_a_file_keep_both() {
+        // The composability case, and the reason files_append exists: two
+        // delivery hooks each contribute one overlay. Under the generic array
+        // rule the second replaced the first and one .dtbo vanished with no
+        // warning, so the collision guard never even saw it.
+        let mut base = serde_json::json!({
+            "build_args": {
+                "type": "fat",
+                "files_append": [{"in": "a.dtbo", "out": "overlays/a.dtbo"}]
+            }
+        });
+        let overlay = serde_json::json!({
+            "build_args": {
+                "files_append": [{"in": "b.dtbo", "out": "overlays/b.dtbo"}]
+            }
+        });
+
+        deep_merge_json(&mut base, overlay);
+
+        let appended = base["build_args"]["files_append"].as_array().unwrap();
+        assert_eq!(appended.len(), 2, "both overlays must survive the merge");
+        assert_eq!(appended[0]["in"], "a.dtbo");
+        assert_eq!(appended[1]["in"], "b.dtbo");
+    }
+
+    #[test]
+    fn an_overlay_still_replaces_the_base_files_list() {
+        // The other half of the same decision. `files` keeps replace semantics
+        // - that is precisely why files_append had to exist - so appending must
+        // not leak into it.
+        let mut base = serde_json::json!({
+            "build_args": {"files": [{"in": "old.bin", "out": "old.bin"}]}
+        });
+        let overlay = serde_json::json!({
+            "build_args": {"files": [{"in": "new.bin", "out": "new.bin"}]}
+        });
+
+        deep_merge_json(&mut base, overlay);
+
+        let files = base["build_args"]["files"].as_array().unwrap();
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0]["in"], "new.bin");
+    }
+
+    #[test]
+    fn a_case_variant_output_is_a_collision_not_a_second_file() {
+        // fatfs resolves names case-insensitively and create_file does not
+        // truncate, so these two would have become one entry holding the
+        // overlay's bytes followed by the tail of the original.
+        let base = vec![FileEntry::Object {
+            input: "vc4-kms-v3d-pi5.dtbo".to_string(),
+            output: "overlays/vc4-kms-v3d-pi5.dtbo".to_string(),
+        }];
+        let append = vec![FileEntry::Object {
+            input: "user.dtbo".to_string(),
+            output: "overlays/VC4-KMS-V3D-PI5.DTBO".to_string(),
+        }];
+
+        let err = merge_fat_files(&base, &append).unwrap_err();
+        assert!(err.contains("Conflicting FAT file entries"), "{err}");
+        assert!(
+            !err.starts_with("[ERROR]"),
+            "the caller's log_error adds that prefix; carrying it here printed it twice: {err}"
+        );
+    }
+
+    #[test]
+    fn path_form_variants_of_one_output_collide() {
+        let base = vec![FileEntry::Object {
+            input: "a.bin".to_string(),
+            output: "./boot//x.bin".to_string(),
+        }];
+        let append = vec![FileEntry::Object {
+            input: "b.bin".to_string(),
+            output: "boot/x.bin".to_string(),
+        }];
+
+        assert!(merge_fat_files(&base, &append).is_err());
+    }
+
+    #[test]
+    fn duplicate_outputs_within_base_files_are_not_a_collision() {
+        // Pre-existing manifests did this and built; the dedup is a property of
+        // appending, so turning base-vs-base into a hard error would break
+        // manifests nobody edited.
+        let base = vec![
+            FileEntry::Object {
+                input: "a.bin".to_string(),
+                output: "shared".to_string(),
+            },
+            FileEntry::Object {
+                input: "b.bin".to_string(),
+                output: "shared".to_string(),
+            },
+        ];
+
+        let merged = merge_fat_files(&base, &[]).unwrap();
+        assert_eq!(merged.len(), 2, "base entries pass through unexamined");
     }
 }

--- a/tests/commands/stone/bundle/mod.rs
+++ b/tests/commands/stone/bundle/mod.rs
@@ -134,8 +134,7 @@ fn test_bundle_missing_partition_size_override_errors() {
         .assert()
         .failure()
         .stdout(
-            predicates::str::contains("var")
-                .and(predicates::str::contains("--partition-size")),
+            predicates::str::contains("var").and(predicates::str::contains("--partition-size")),
         );
 }
 

--- a/tests/commands/stone/files_append/mod.rs
+++ b/tests/commands/stone/files_append/mod.rs
@@ -1,0 +1,214 @@
+//! End-to-end coverage for `files_append`.
+//!
+//! The unit tests in `src/manifest.rs` exercise `merge_fat_files` in isolation,
+//! which is exactly why every consumer outside it was left unwired: nothing
+//! drove `bundle`, `create`, `validate` or `describe-manifest` with an append
+//! entry, so the accessor could stay `#[allow(dead_code)]` and the suite stayed
+//! green. These tests assert observable state after a real command run, per the
+//! repo's integration-test rule.
+
+use assert_cmd::Command;
+use predicates::prelude::PredicateBooleanExt;
+use std::fs;
+use tempfile::TempDir;
+
+const OS_RELEASE: &str = r#"NAME="Avocado Linux"
+VERSION="1.0.0"
+ID=avocado
+VERSION_ID="1.0.0"
+VERSION_CODENAME=test
+PRETTY_NAME="Avocado Linux 1.0.0"
+AVOCADO_OS_BUILD_ID=test-build-id
+"#;
+
+/// Inputs for a manifest whose boot image has one base FAT file and one
+/// appended one. Both source files exist, so anything that fails to stage the
+/// appended one is a wiring bug rather than a missing input.
+fn write_inputs(dir: &std::path::Path) {
+    fs::write(dir.join("os-release"), OS_RELEASE).unwrap();
+    fs::write(dir.join("avocado-image-var.btrfs"), b"dummy var image").unwrap();
+    fs::write(dir.join("bzImage"), b"dummy kernel").unwrap();
+    fs::write(dir.join("a.dtbo"), b"dummy overlay").unwrap();
+}
+
+fn manifest_with_append(files_append: &str) -> String {
+    format!(
+        r#"{{
+        "runtime": {{"platform": "linux", "architecture": "x86_64"}},
+        "storage_devices": {{
+            "main": {{
+                "out": "disk.img",
+                "devpath": "/dev/sda",
+                "images": {{
+                    "var": "avocado-image-var.btrfs",
+                    "boot": {{
+                        "out": "boot.img",
+                        "size": 64,
+                        "size_unit": "mebibytes",
+                        "build_args": {{
+                            "type": "fat",
+                            "variant": "FAT32",
+                            "files": [{{"in": "bzImage", "out": "bzImage"}}],
+                            "files_append": [{files_append}]
+                        }}
+                    }}
+                }},
+                "partitions": [
+                    {{"name": "boot", "image": "boot", "size": 64, "size_unit": "mebibytes"}},
+                    {{"name": "var", "image": "var", "expand": "true",
+                     "size": 64, "size_unit": "mebibytes"}}
+                ]
+            }}
+        }}
+    }}"#
+    )
+}
+
+fn run_bundle(
+    input: &std::path::Path,
+    build_dir: &std::path::Path,
+    output: &std::path::Path,
+) -> assert_cmd::assert::Assert {
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "bundle",
+            "-m",
+            &input.join("manifest.json").to_string_lossy(),
+            "--os-release",
+            &input.join("os-release").to_string_lossy(),
+            "-i",
+            &input.to_string_lossy(),
+            "-o",
+            &output.to_string_lossy(),
+            "--build-dir",
+            &build_dir.to_string_lossy(),
+        ])
+        .assert()
+}
+
+#[test]
+fn bundle_stages_files_append_inputs_beside_the_base_ones() {
+    // The blocking one. `stone bundle` succeeds and the bundle records the
+    // appended entry, but if only `files` is staged the source never reaches
+    // the build dir - and `stone provision` then dies with "not found in any
+    // input directory", one command later and far from the cause.
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path();
+    write_inputs(input);
+    fs::write(
+        input.join("manifest.json"),
+        manifest_with_append(r#"{"in": "a.dtbo", "out": "overlays/a.dtbo"}"#),
+    )
+    .unwrap();
+
+    let build_dir = temp_dir.path().join("_build");
+    let output = temp_dir.path().join("os-bundle.aos");
+    run_bundle(input, &build_dir, &output).success();
+
+    assert!(
+        build_dir.join("bzImage").exists(),
+        "the base FAT input must be staged"
+    );
+    assert!(
+        build_dir.join("a.dtbo").exists(),
+        "the files_append input must be staged too, or provision cannot rebuild the FAT image"
+    );
+}
+
+#[test]
+fn bundle_rejects_an_append_that_collides_with_a_base_output_by_case() {
+    // FAT lookup is case-insensitive and `create_file` returns the existing
+    // entry without truncating, so a case-variant duplicate overwrites the base
+    // boot file in place and leaves its tail readable past the new data. The
+    // guard has to catch this before the image is written, not after.
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path();
+    write_inputs(input);
+    fs::write(
+        input.join("manifest.json"),
+        manifest_with_append(r#"{"in": "a.dtbo", "out": "BZIMAGE"}"#),
+    )
+    .unwrap();
+
+    let build_dir = temp_dir.path().join("_build");
+    let output = temp_dir.path().join("os-bundle.aos");
+    run_bundle(input, &build_dir, &output)
+        .failure()
+        .stdout(predicates::str::contains("BZIMAGE").or(predicates::str::contains("bzImage")));
+}
+
+#[test]
+fn a_duplicate_output_within_files_alone_still_builds() {
+    // Compat guard. The dedup exists for the append list; a manifest that
+    // already had two base `files` entries sharing an output built before this
+    // feature and must keep building, or the change is a silent break for
+    // manifests nobody touched.
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path();
+    write_inputs(input);
+    fs::write(input.join("b.bin"), b"second input").unwrap();
+
+    let manifest = r#"{
+        "runtime": {"platform": "linux", "architecture": "x86_64"},
+        "storage_devices": {
+            "main": {
+                "out": "disk.img",
+                "devpath": "/dev/sda",
+                "images": {
+                    "var": "avocado-image-var.btrfs",
+                    "boot": {
+                        "out": "boot.img",
+                        "size": 64,
+                        "size_unit": "mebibytes",
+                        "build_args": {
+                            "type": "fat",
+                            "variant": "FAT32",
+                            "files": [
+                                {"in": "bzImage", "out": "shared"},
+                                {"in": "b.bin", "out": "shared"}
+                            ]
+                        }
+                    }
+                },
+                "partitions": [
+                    {"name": "boot", "image": "boot", "size": 64, "size_unit": "mebibytes"},
+                    {"name": "var", "image": "var", "expand": "true",
+                     "size": 64, "size_unit": "mebibytes"}
+                ]
+            }
+        }
+    }"#;
+    fs::write(input.join("manifest.json"), manifest).unwrap();
+
+    let build_dir = temp_dir.path().join("_build");
+    let output = temp_dir.path().join("os-bundle.aos");
+    run_bundle(input, &build_dir, &output).success();
+}
+
+#[test]
+fn describe_manifest_lists_the_appended_file_not_just_its_count() {
+    // A misplaced or misspelled `files_append` key is silently ignored, so
+    // describe-manifest is the operator's only confirmation the append landed.
+    // A count with no name beside it cannot distinguish "landed" from "landed
+    // as something else".
+    let temp_dir = TempDir::new().unwrap();
+    let input = temp_dir.path();
+    write_inputs(input);
+    fs::write(
+        input.join("manifest.json"),
+        manifest_with_append(r#"{"in": "a.dtbo", "out": "overlays/a.dtbo"}"#),
+    )
+    .unwrap();
+
+    Command::cargo_bin("stone")
+        .unwrap()
+        .args([
+            "describe-manifest",
+            "-m",
+            &input.join("manifest.json").to_string_lossy(),
+        ])
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("overlays/a.dtbo"));
+}

--- a/tests/commands/stone/mod.rs
+++ b/tests/commands/stone/mod.rs
@@ -1,5 +1,6 @@
 pub mod bundle;
 pub mod create;
 pub mod describe_manifest;
+pub mod files_append;
 pub mod provision;
 pub mod validate;


### PR DESCRIPTION
## Problem

The device-tree-overlay feature needs to add compiled `.dtbo` files to a target's FAT boot partition at bundle time, but stone's manifest had no way to append files to an existing FAT image.

## Solution

Add `files_append` support to the manifest so additional files are injected into a FAT partition image without redefining it.

## Key changes

- manifest: support additive FAT files via `files_append`
- provision: bind guarded partition size with `if let`

## Reviewer notes

Enabler for the Avocado device-tree-overlay feature (ENG-2134). meta-avocado's overlay delivery hook and the avocado-cli DTO commands build on this. First to merge in the stack: stone -> meta-avocado -> avocado-cli.
